### PR TITLE
Upstream support for Ford

### DIFF
--- a/selfdrive/car/ford/carstate.py
+++ b/selfdrive/car/ford/carstate.py
@@ -4,7 +4,7 @@ from opendbc.can.can_define import CANDefine
 from opendbc.can.parser import CANParser
 from openpilot.selfdrive.car.interfaces import CarStateBase
 from openpilot.selfdrive.car.ford.fordcan import CanBus
-from openpilot.selfdrive.car.ford.values import CANFD_CAR, CarControllerParams, DBC
+from openpilot.selfdrive.car.ford.values import CANFD_CAR, FORD_EV, CarControllerParams, DBC
 
 GearShifter = car.CarState.GearShifter
 TransmissionType = car.CarParams.TransmissionType
@@ -26,7 +26,10 @@ class CarState(CarStateBase):
     # Hybrid variants experience a bug where a message from the PCM sends invalid checksums,
     # we do not support these cars at this time.
     # TrnAin_Tq_Actl and its quality flag are only set on ICE platform variants
-    self.hybrid_platform = cp.vl["VehicleOperatingModes"]["TrnAinTq_D_Qf"] == 0
+    if self.CP.carFingerprint in FORD_EV:
+      self.hybrid_platform = False
+    else:
+      self.hybrid_platform = cp.vl["VehicleOperatingModes"]["TrnAinTq_D_Qf"] == 0
 
     # Occasionally on startup, the ABS module recalibrates the steering pinion offset, so we need to block engagement
     # The vehicle usually recovers out of this state within a minute of normal driving

--- a/selfdrive/car/ford/fordcan.py
+++ b/selfdrive/car/ford/fordcan.py
@@ -129,14 +129,15 @@ def create_acc_msg(packer, CAN: CanBus, long_active: bool, gas: float, accel: fl
   """
 
   decel = accel < 0 and long_active
+  newDecelValue = gas == -5 and long_active
   values = {
     "AccBrkTot_A_Rq": accel,                          # Brake total accel request: [-20|11.9449] m/s^2
     "Cmbb_B_Enbl": 1 if long_active else 0,           # Enabled: 0=No, 1=Yes
     "AccPrpl_A_Rq": gas,                              # Acceleration request: [-5|5.23] m/s^2
     "AccResumEnbl_B_Rq": 1 if long_active else 0,
     # TODO: we may be able to improve braking response by utilizing pre-charging better
-    "AccBrkPrchg_B_Rq": 1 if decel else 0,            # Pre-charge brake request: 0=No, 1=Yes
-    "AccBrkDecel_B_Rq": 1 if decel else 0,            # Deceleration request: 0=Inactive, 1=Active
+    "AccBrkPrchg_B_Rq": 1 if newDecelValue else 0,            # Pre-charge brake request: 0=No, 1=Yes
+    "AccBrkDecel_B_Rq": 1 if newDecelValue else 0,            # Deceleration request: 0=Inactive, 1=Active
     "AccStopStat_B_Rq": 1 if stopping else 0,
   }
   return packer.make_can_msg("ACCDATA", CAN.main, values)

--- a/selfdrive/car/ford/fordcan.py
+++ b/selfdrive/car/ford/fordcan.py
@@ -128,7 +128,6 @@ def create_acc_msg(packer, CAN: CanBus, long_active: bool, gas: float, accel: fl
   Frequency is 50Hz.
   """
 
-  decel = accel < 0 and long_active
   newDecelValue = gas == -5 and long_active
   values = {
     "AccBrkTot_A_Rq": accel,                          # Brake total accel request: [-20|11.9449] m/s^2

--- a/selfdrive/car/ford/interface.py
+++ b/selfdrive/car/ford/interface.py
@@ -56,6 +56,15 @@ class CarInterface(CarInterfaceBase):
       ret.steerRatio = 17.0
       ret.mass = 2000
 
+    elif candidate == CAR.F_150_LIGHTNING_MK1:
+      ret.wheelbase = 3.69
+      ret.steerRatio = 17.0
+      ret.mass = 2729
+
+      ret.longitudinalTuning.kpBP = [0.]
+      ret.longitudinalTuning.kpV = [0.5]
+      ret.longitudinalTuning.kiV = [0.]
+
     elif candidate == CAR.FOCUS_MK4:
       ret.wheelbase = 2.7
       ret.steerRatio = 15.0

--- a/selfdrive/car/ford/values.py
+++ b/selfdrive/car/ford/values.py
@@ -47,9 +47,11 @@ class CAR(StrEnum):
   F_150_MK14 = "FORD F-150 14TH GEN"
   FOCUS_MK4 = "FORD FOCUS 4TH GEN"
   MAVERICK_MK1 = "FORD MAVERICK 1ST GEN"
+  F_150_LIGHTNING_MK1 = "FORD F-150 LIGHTNING 1ST GEN"
 
 
-CANFD_CAR = {CAR.F_150_MK14}
+CANFD_CAR = {CAR.F_150_MK14, CAR.F_150_LIGHTNING_MK1}
+FORD_EV = {CAR.F_150_LIGHTNING_MK1}
 
 
 class RADAR:
@@ -60,7 +62,7 @@ class RADAR:
 DBC: Dict[str, Dict[str, str]] = defaultdict(lambda: dbc_dict("ford_lincoln_base_pt", RADAR.DELPHI_MRR))
 
 # F-150 radar is not yet supported
-DBC[CAR.F_150_MK14] = dbc_dict("ford_lincoln_base_pt", None)
+DBC[CAR.F_150_MK14, CAR.F_150_LIGHTNING_MK1] = dbc_dict("ford_lincoln_base_pt", None)
 
 
 class Footnote(Enum):
@@ -79,6 +81,8 @@ class FordCarInfo(CarInfo):
   def init_make(self, CP: car.CarParams):
     if CP.carFingerprint in (CAR.BRONCO_SPORT_MK1, CAR.MAVERICK_MK1):
       self.car_parts = CarParts([Device.threex_angled_mount, CarHarness.ford_q3])
+    if CP.carFingerprint in (CAR.F_150_LIGHTNING_MK1):
+      SELF.car_parts = CarParts([Device.threex_angled_mount, CarHarness.ford_q4])
 
 
 CAR_INFO: Dict[str, Union[CarInfo, List[CarInfo]]] = {
@@ -92,6 +96,7 @@ CAR_INFO: Dict[str, Union[CarInfo, List[CarInfo]]] = {
     FordCarInfo("Lincoln Aviator 2020-21", "Co-Pilot360 Plus"),
   ],
   CAR.F_150_MK14: FordCarInfo("Ford F-150 2023", "Co-Pilot360 Active 2.0"),
+  CAR.F_150_LIGHTNING_MK1: FordCarInfo("Ford F-150 Lightning 2022-2023", "Co-Pilot360 Active 2.0"),
   CAR.FOCUS_MK4: FordCarInfo("Ford Focus 2018", "Adaptive Cruise Control with Lane Centering", footnotes=[Footnote.FOCUS]),
   CAR.MAVERICK_MK1: [
     FordCarInfo("Ford Maverick 2022", "LARIAT Luxury"),
@@ -228,6 +233,11 @@ FW_VERSIONS = {
     ],
     (Ecu.engine, 0x7E0, None): [
       b'PL3A-14C204-BRB\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+    ],
+  },
+  CAR.F_150_LIGHTNING_MK1: {
+    (Ecu.shiftByWire, 0x732, None): [
+      b'ML3P-7P470-AK\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
     ],
   },
   CAR.FOCUS_MK4: {

--- a/selfdrive/car/torque_data/override.yaml
+++ b/selfdrive/car/torque_data/override.yaml
@@ -25,6 +25,7 @@ FORD BRONCO SPORT 1ST GEN: [.nan, 1.5, .nan]
 FORD ESCAPE 4TH GEN: [.nan, 1.5, .nan]
 FORD EXPLORER 6TH GEN: [.nan, 1.5, .nan]
 FORD F-150 14TH GEN: [.nan, 1.5, .nan]
+FORD F-150 LIGHTNING 1ST GEN: [.nan, 1.5, .nan]
 FORD FOCUS 4TH GEN: [.nan, 1.5, .nan]
 FORD MAVERICK 1ST GEN: [.nan, 1.5, .nan]
 ###

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -143,6 +143,8 @@ class Controls:
 
     car_recognized = self.CP.carName != 'mock'
 
+    is_ford_vehicle = "ford" in self.CP.carName
+
     controller_available = self.CI.CC is not None and not passive and not self.CP.dashcamOnly
     self.read_only = not car_recognized or not controller_available or self.CP.dashcamOnly
     if self.read_only:
@@ -702,7 +704,7 @@ class Controls:
 
     # Send a "steering required alert" if saturation count has reached the limit
     if lac_log.active and not recent_steer_pressed and not self.CP.notCar:
-      if False:
+      if self.CP.lateralTuning.which() == 'torque' and not self.joystick_mode and not is_ford_vehicle:
         undershooting = abs(lac_log.desiredLateralAccel) / abs(1e-3 + lac_log.actualLateralAccel) > 1.2
         turning = abs(lac_log.desiredLateralAccel) > 1.0
         good_speed = CS.vEgo > 5

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -704,7 +704,7 @@ class Controls:
 
     # Send a "steering required alert" if saturation count has reached the limit
     if lac_log.active and not recent_steer_pressed and not self.CP.notCar:
-      if self.CP.lateralTuning.which() == 'torque' and not self.joystick_mode and not is_ford_vehicle:
+      if self.CP.lateralTuning.which() == 'torque' and not self.joystick_mode and not self.is_ford_vehicle:
         undershooting = abs(lac_log.desiredLateralAccel) / abs(1e-3 + lac_log.actualLateralAccel) > 1.2
         turning = abs(lac_log.desiredLateralAccel) > 1.0
         good_speed = CS.vEgo > 5

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -143,7 +143,7 @@ class Controls:
 
     car_recognized = self.CP.carName != 'mock'
 
-    is_ford_vehicle = "ford" in self.CP.carName
+    is_ford_vehicle = "FORD" in self.CP.carName
 
     controller_available = self.CI.CC is not None and not passive and not self.CP.dashcamOnly
     self.read_only = not car_recognized or not controller_available or self.CP.dashcamOnly

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -702,7 +702,7 @@ class Controls:
 
     # Send a "steering required alert" if saturation count has reached the limit
     if lac_log.active and not recent_steer_pressed and not self.CP.notCar:
-      if self.CP.lateralTuning.which() == 'torque' and not self.joystick_mode:
+      if False:
         undershooting = abs(lac_log.desiredLateralAccel) / abs(1e-3 + lac_log.actualLateralAccel) > 1.2
         turning = abs(lac_log.desiredLateralAccel) > 1.0
         good_speed = CS.vEgo > 5

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -143,7 +143,7 @@ class Controls:
 
     car_recognized = self.CP.carName != 'mock'
 
-    is_ford_vehicle = "FORD" in self.CP.carName
+    is_ford_vehicle = "ford" in self.CP.carName
 
     controller_available = self.CI.CC is not None and not passive and not self.CP.dashcamOnly
     self.read_only = not car_recognized or not controller_available or self.CP.dashcamOnly

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -143,7 +143,7 @@ class Controls:
 
     car_recognized = self.CP.carName != 'mock'
 
-    is_ford_vehicle = "ford" in self.CP.carName
+    is_ford_vehicle = self.CP.carName == 'ford'
 
     controller_available = self.CI.CC is not None and not passive and not self.CP.dashcamOnly
     self.read_only = not car_recognized or not controller_available or self.CP.dashcamOnly

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -143,7 +143,7 @@ class Controls:
 
     car_recognized = self.CP.carName != 'mock'
 
-    is_ford_vehicle = self.CP.carName == 'ford'
+    self.is_ford_vehicle = self.CP.carName == 'ford'
 
     controller_available = self.CI.CC is not None and not passive and not self.CP.dashcamOnly
     self.read_only = not car_recognized or not controller_available or self.CP.dashcamOnly


### PR DESCRIPTION
Don't mind all the commits. Still getting used to python (coming from C#)

This adds a bool to check if the carName is 'ford'. If it is, we bypass the line that's causing a controls mismatch until Twilsonco can get his fix added to master. 

Additionally, this adds support for Ford CAN-FD vehicles, mainly the F150 Lightning. This will be followed shortly by a PR to allow the user to select F150 Lightning/F150 ICE/Mach E. Currently, these CAN-FD platforms are having problems with the ISO-TP queries preventing proper fingerprints [29085](https://github.com/commaai/openpilot/issues/29085)

Additionally, this allows the Ford ACC commands to behave as the stock ones do. Mainly, this allows the precharging to happen immediately when the gas is at -5 (no input). This allows for a shorter, smoother stopping for the vehicle.