### PR TITLE
NNFF "lookahead" lateral jerk 

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -87,7 +87,8 @@ class FluxModel:
       self.layers.append((W, b, activation))
 
     self.validate_layers()
-
+    self.check_for_friction_override()
+    
   # Begin activation functions.
   # These are called by name using the keys in the model json file
   def sigmoid(self, x):
@@ -125,7 +126,10 @@ class FluxModel:
     for W, b, activation in self.layers:
       if not hasattr(self, activation):
         raise ValueError(f"Unknown activation: {activation}")
-
+  def check_for_friction_override(self):
+    y = self.evaluate([10.0, 0.0, 0.2])
+    self.friction_override = (y < 0.1)
+  
 def get_nn_model_path(car, eps_firmware) -> Tuple[Union[str, None, float]]:
   def check_nn_path(check_model):
     model_path = None

--- a/selfdrive/controls/lib/latcontrol_torque.py
+++ b/selfdrive/controls/lib/latcontrol_torque.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from cereal import log
 from openpilot.common.numpy_fast import interp
-from openpilot.selfdrive.controls.lib.drive_helpers import CONTROL_N
+from openpilot.selfdrive.controls.lib.drive_helpers import CONTROL_N, apply_deadzone
 from openpilot.selfdrive.controls.lib.latcontrol import LatControl
 from openpilot.selfdrive.controls.lib.pid import PIDController
 from openpilot.selfdrive.controls.lib.vehicle_model import ACCELERATION_DUE_TO_GRAVITY
@@ -23,7 +23,7 @@ from openpilot.selfdrive.modeld.constants import T_IDXS
 
 LOW_SPEED_X = [0, 10, 20, 30]
 LOW_SPEED_Y = [15, 13, 10, 5]
-LOW_SPEED_Y_NN = [12, 10, 7, 3]
+LOW_SPEED_Y_NN = [8, 4, 1, 0]
 
 # Takes past errors (v) and associated relative times (t) and returns a function
 # that can be used to predict future errors. The function takes a time (t) and
@@ -36,6 +36,24 @@ def get_predict_error_func(v, t, a=1.5):
     return np.exp(-a * t) * (m * t + c)
 
   return error
+
+def sign(x):
+  return 1.0 if x > 0.0 else (-1.0 if x < 0.0 else 0.0)
+
+LAT_PLAN_MIN_IDX = 5
+def get_lookahead_value(future_vals, current_val):
+  if len(future_vals) == 0:
+    return current_val
+  
+  same_sign_vals = [v for v in future_vals if sign(v) == sign(current_val)]
+  
+  # if any future val has opposite sign of current val, return 0
+  if len(same_sign_vals) < len(future_vals):
+    return 0.0
+  
+  # otherwise return the value with minimum absolute value
+  min_val = min(same_sign_vals + [current_val], key=lambda x: abs(x))
+  return min_val
 
 class LatControlTorque(LatControl):
   def __init__(self, CP, CI):
@@ -55,6 +73,8 @@ class LatControlTorque(LatControl):
       # Past value is computed using previous desired lat accel and observed roll
       self.torque_from_nn = CI.get_ff_nn
       self.nn_friction_override = CI.lat_torque_nn_model.friction_override
+      self.friction_look_ahead_v = [0.3, 1.2]
+      self.friction_look_ahead_bp = [9.0, 35.0]
       
       # setup future time offsets
       self.nn_time_offset = CP.steerActuatorDelay + 0.2
@@ -115,6 +135,12 @@ class LatControlTorque(LatControl):
         self.roll_deque.append(roll)
         self.lateral_accel_desired_deque.append(desired_lateral_accel)
         self.error_deque.append(error)
+        
+        # prepare "look-ahead" desired lateral jerk
+        lookahead = interp(CS.vEgo, self.friction_look_ahead_bp, self.friction_look_ahead_v)
+        friction_upper_idx = next((i for i, val in enumerate(T_IDXS) if val > lookahead), 16)
+        lookahead_curvature_rate = get_lookahead_value(list(lat_plan.curvatureRates)[LAT_PLAN_MIN_IDX:friction_upper_idx], desired_curvature_rate)
+        lookahead_lateral_jerk = lookahead_curvature_rate * CS.vEgo**2
 
         # prepare past and future values
         # adjust future times to account for longitudinal acceleration
@@ -126,24 +152,32 @@ class LatControlTorque(LatControl):
         past_errors = [self.error_deque[min(len(self.error_deque)-1, i)] for i in self.history_frame_offsets]
         future_error_func = get_predict_error_func(past_errors + [error], self.past_times + [0.0])
         future_errors = future_error_func(self.nn_future_times_np).tolist()
+        
+        # compute NN error response        
+        lat_jerk_deadzone = 0.35
+        lateral_jerk_error = 0.0 if self.use_steering_angle or abs(lookahead_lateral_jerk) <= lat_jerk_deadzone else (0.1 * apply_deadzone(lookahead_lateral_jerk - actual_lateral_jerk, lat_jerk_deadzone))
 
-        # compute NN error response
-        lateral_jerk_error = 0.1 * (desired_lateral_jerk - actual_lateral_jerk)
-        nn_error_input = [CS.vEgo, error, lateral_jerk_error, 0.0] \
+        friction_input = error + lateral_jerk_error
+        nn_error_input = [CS.vEgo, error, friction_input, 0.0] \
                               + past_errors + future_errors
         pid_log.error = self.torque_from_nn(nn_error_input)
-
-        # add in friction compensation for NNFFs that need it
-        if self.nn_friction_override:
-          pid_log.error += self.torque_from_lateral_accel(0.0, self.torque_params,
-                                            error,
-                                            lateral_accel_deadzone, friction_compensation=True)
         
         # compute feedforward (same as nn setpoint output)
-        nn_input = [CS.vEgo, desired_lateral_accel, error, roll] \
+        
+        lookahead_lateral_jerk = apply_deadzone(lookahead_lateral_jerk, lat_jerk_deadzone)
+        nn_input = [CS.vEgo, desired_lateral_accel, lookahead_lateral_jerk, roll] \
                               + past_lateral_accels_desired + future_planned_lateral_accels \
                               + past_rolls + future_rolls
         ff = self.torque_from_nn(nn_input)
+        
+        # apply friction override for cars with low NN friction response
+        if self.nn_friction_override:
+          pid_log.error += self.torque_from_lateral_accel(0.0, self.torque_params,
+                                            friction_input,
+                                            lateral_accel_deadzone, friction_compensation=True)
+          ff += self.torque_from_lateral_accel(0.0, self.torque_params,
+                                            lookahead_lateral_jerk,
+                                            lateral_accel_deadzone, friction_compensation=True)
         nn_log = nn_input + nn_error_input
       else:
         gravity_adjusted_lateral_accel = desired_lateral_accel - params.roll * ACCELERATION_DUE_TO_GRAVITY


### PR DESCRIPTION
Before NNFF, there was "lookahead" lateral jerk. [A nice trick to only consider "deliberate" desired lateral jerk](https://github.com/twilsonco/openpilot/blob/log-info/sec/1%20History%20and%20future%20of%20data-driven%20controls%20improvments.md#only-commanding-deliberate-lateral-jerk).

Then I stopped using that with NNFF, hoping that I could get the same effect, but in a superior way "learned" by NNFF for each car. Unfortunately, it doesn't work out as well as I'd hoped. 

Bringing back lookahead lateral jerk with nnff means that now there is an improved "friction" component to the feedforward, in addition to the "friction" component of the error response. So NNFF now knows how to overcome steering column friction for _planned_ steering changes, as well as for corrections to steering error.

---

This also adds "friction override". For some cars, NNFF recovers basically zero friction response. At first I thought to trust the NNFF, but based on user feedback from the affected cars, the result is lazy lateral corrections. So, at startup, the NNFF model is tested to see if it has a "sufficient" friction response. If not, we use comma's determined value for the friction coefficient, and add that on top of NNFF output, so that every car either gets the NNFF friction, if learned, and falls back on comma's friction (for both error correction and feedforward friction).