### PR TITLE
Add hardware forwarded BSM message for Bolt EUV

### DIFF
--- a/opendbc/gm_global_a_powertrain_generated.dbc
+++ b/opendbc/gm_global_a_powertrain_generated.dbc
@@ -79,6 +79,11 @@ VAL_TABLE_ LKATorqueDeliveredStatus 3 "Failed" 2 "Temp. Limited" 1 "Active" 0 "I
 VAL_TABLE_ HandsOffSWDetectionStatus 1 "Hands On" 0 "Hands Off" ;
 VAL_TABLE_ HandsOffSWDetectionMode 2 "Failed" 1 "Enabled" 0 "Disabled" ;
 
+BO_ 1 left_blindspot: 8 XXX
+ SG_ leftbsmlight : 4|1@1+ (1,0) [0|1] "" XXX
+
+BO_ 2 right_blindspot: 8 XXX
+ SG_ rightbsmlight : 0|1@1+ (1,0) [0|1] "" XXX
 
 BO_ 189 EBCMRegenPaddle: 7 K17_EBCM
  SG_ RegenPaddle : 7|4@0+ (1,0) [0|0] ""  NEO

--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -41,9 +41,9 @@ class CarState(CarStateBase):
     self.moving_backward = (pt_cp.vl["EBCMWheelSpdRear"]["MovingBackward"] != 0) and not moving_forward
    
     #Forwarded BSM message
-    if self.CP.enableBsm:
-      ret.leftBlindspot = cp.vl["left_blindspot"]["leftbsmlight"] == 1
-      ret.rightBlindspot = cp.vl["right_blindspot"]["rightbsmlight"] == 1
+    
+    ret.leftBlindspot = cp.vl["left_blindspot"]["leftbsmlight"] == 1
+    ret.rightBlindspot = cp.vl["right_blindspot"]["rightbsmlight"] == 1
       
     # Variables used for avoiding LKAS faults
     self.loopback_lka_steering_cmd_updated = len(loopback_cp.vl_all["ASCMLKASteeringCmd"]["RollingCounter"]) > 0

--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -42,8 +42,8 @@ class CarState(CarStateBase):
    
     #Forwarded BSM message
     
-    ret.leftBlindspot = cp.vl["left_blindspot"]["leftbsmlight"] == 1
-    ret.rightBlindspot = cp.vl["right_blindspot"]["rightbsmlight"] == 1
+    ret.leftBlindspot = pt_cp.vl["left_blindspot"]["leftbsmlight"] == 1
+    ret.rightBlindspot = pt_cp.vl["right_blindspot"]["rightbsmlight"] == 1
       
     # Variables used for avoiding LKAS faults
     self.loopback_lka_steering_cmd_updated = len(loopback_cp.vl_all["ASCMLKASteeringCmd"]["RollingCounter"]) > 0

--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -39,7 +39,12 @@ class CarState(CarStateBase):
     self.pscm_status = copy.copy(pt_cp.vl["PSCMStatus"])
     moving_forward = pt_cp.vl["EBCMWheelSpdRear"]["MovingForward"] != 0
     self.moving_backward = (pt_cp.vl["EBCMWheelSpdRear"]["MovingBackward"] != 0) and not moving_forward
-
+   
+    #Forwarded BSM message
+    if self.CP.enableBsm:
+      ret.leftBlindspot = cp.vl["left_blindspot"]["leftbsmlight"] == 1
+      ret.rightBlindspot = cp.vl["right_blindspot"]["rightbsmlight"] == 1
+      
     # Variables used for avoiding LKAS faults
     self.loopback_lka_steering_cmd_updated = len(loopback_cp.vl_all["ASCMLKASteeringCmd"]["RollingCounter"]) > 0
     if self.loopback_lka_steering_cmd_updated:

--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -42,8 +42,8 @@ class CarState(CarStateBase):
    
     #Forwarded BSM message
     
-    ret.leftBlindspot = pt_cp.vl["left_blindspot"]["leftbsmlight"] == 1
-    ret.rightBlindspot = pt_cp.vl["right_blindspot"]["rightbsmlight"] == 1
+    ret.leftBlindspot = pt_cp.vl.get("left_blindspot", {}).get("leftbsmlight", 0) == 1
+    ret.rightBlindspot = pt_cp.vl.get("right_blindspot", {}).get("rightbsmlight", 0) == 1
       
     # Variables used for avoiding LKAS faults
     self.loopback_lka_steering_cmd_updated = len(loopback_cp.vl_all["ASCMLKASteeringCmd"]["RollingCounter"]) > 0

--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -42,8 +42,8 @@ class CarState(CarStateBase):
    
     #Forwarded BSM message
     
-    ret.leftBlindspot = pt_cp.vl.get("left_blindspot", {}).get("leftbsmlight", 0) == 1
-    ret.rightBlindspot = pt_cp.vl.get("right_blindspot", {}).get("rightbsmlight", 0) == 1
+    ret.leftBlindspot = pt_cp.vl["left_blindspot"]["leftbsmlight"] == 1
+    ret.rightBlindspot = pt_cp.vl["right_blindspot"]["rightbsmlight"] == 1
       
     # Variables used for avoiding LKAS faults
     self.loopback_lka_steering_cmd_updated = len(loopback_cp.vl_all["ASCMLKASteeringCmd"]["RollingCounter"]) > 0
@@ -229,6 +229,9 @@ class CarState(CarStateBase):
         ("EBCMRegenPaddle", 50),
         ("EVDriveMode", 0),
       ]
+      #bsm does not send a signal until the first instance of it lighting up
+    messages.append(("left_blindspot", 0))
+    messages.append(("right_blindspot", 0))
 
     if CP.carFingerprint in CC_ONLY_CAR:
       messages += [


### PR DESCRIPTION
BSM message is forwarded from the gmlan low-speed bus to the highspeed pt bus using an Arduino-based microcontroller. Only the enabled status is forwarded to the PT bus for a clean signal as I do not fully understand the rest of the signal.

Based off https://github.com/ServerDummy/Teensy_BSM

