### PR TITLE
torque: lateral jerk with stock torque controller

### DIFF
--- a/selfdrive/controls/lib/latcontrol_torque.py
+++ b/selfdrive/controls/lib/latcontrol_torque.py
@@ -61,10 +61,28 @@ class LatControlTorque(LatControl):
     self.torque_from_lateral_accel = CI.torque_from_lateral_accel()
     self.use_steering_angle = self.torque_params.useSteeringAngle
     self.steering_angle_deadzone_deg = self.torque_params.steeringAngleDeadzoneDeg
-    self.lowspeed_factor_factor = 1.0 # in [0, 1] in 0.1 increments.
-
+    
+    self.use_lateral_jerk = True # TODO: make this a parameter in the UI
+    
     # Twilsonco's Lateral Neural Network Feedforward
     self.use_nn = CI.has_lateral_torque_nn
+    
+    if self.use_nn or self.use_lateral_jerk:
+      # Instantaneous lateral jerk changes very rapidly, making it not useful on its own,
+      # however, we can "look ahead" to the future planned lateral jerk in order to guage
+      # whether the current desired lateral jerk will persist into the future, i.e.
+      # whether it's "deliberate" or not. This lets us simply ignore short-lived jerk.
+      # Note that LAT_PLAN_MIN_IDX is defined above and is used in order to prevent
+      # using a "future" value that is actually planned to occur before the "current" desired
+      # value, which is offset by the steerActuatorDelay.
+      self.friction_look_ahead_v = [1.4, 2.0] # how many seconds in the future to look ahead in [0, ~2.1] in 0.1 increments
+      self.friction_look_ahead_bp = [9.0, 30.0] # corresponding speeds in m/s in [0, ~40] in 1.0 increments
+
+      # Scaling the lateral acceleration "friction response" could be helpful for some.
+      # Increase for a stronger response, decrease for a weaker response.
+      self.lat_jerk_friction_factor = 0.4
+      self.lat_accel_friction_factor = 0.7 # in [0, 3], in 0.05 increments. 3 is arbitrary safety limit
+
     if self.use_nn:
       self.pitch = FirstOrderFilter(0.0, 0.5, 0.01)
       self.lowspeed_factor_factor = 1.0
@@ -91,26 +109,6 @@ class LatControlTorque(LatControl):
 
       # Setup adjustable parameters
 
-      # Instantaneous lateral jerk changes very rapidly, making it not useful on its own,
-      # however, we can "look ahead" to the future planned lateral jerk in order to guage
-      # whether the current desired lateral jerk will persist into the future, i.e.
-      # whether it's "deliberate" or not. This lets us simply ignore short-lived jerk.
-      # Note that LAT_PLAN_MIN_IDX is defined above and is used in order to prevent
-      # using a "future" value that is actually planned to occur before the "current" desired
-      # value, which is offset by the steerActuatorDelay.
-      self.friction_look_ahead_v = [0.8, 1.8] # how many seconds in the future to look ahead in [0, ~2.1] in 0.1 increments
-      self.friction_look_ahead_bp = [9.0, 35.0] # corresponding speeds in m/s in [0, ~40] in 1.0 increments
-      # Additionally, we use a deadzone to make sure that we only put additional torque
-      # when the jerk is large enough to be significant.
-      self.lat_jerk_deadzone = 0.0 # m/s^3 in [0, ∞] in 0.05 increments
-      # Finally, lateral jerk error is downscaled so it doesn't dominate the friction error
-      # term.
-      self.lat_jerk_friction_factor = 0.4 # in [0, 3] in 0.05 increments
-
-      # Scaling the lateral acceleration "friction response" could be helpful for some.
-      # Increase for a stronger response, decrease for a weaker response.
-      self.lat_accel_friction_factor = 0.7 # in [0, 3], in 0.05 increments. 3 is arbitrary safety limit
-
   def update_live_torque_params(self, latAccelFactor, latAccelOffset, friction):
     self.torque_params.latAccelFactor = latAccelFactor
     self.torque_params.latAccelOffset = latAccelOffset
@@ -127,7 +125,7 @@ class LatControlTorque(LatControl):
       if self.use_steering_angle:
         actual_curvature = -VM.calc_curvature(math.radians(CS.steeringAngleDeg - params.angleOffsetDeg), CS.vEgo, params.roll)
         curvature_deadzone = abs(VM.calc_curvature(math.radians(self.steering_angle_deadzone_deg), CS.vEgo, 0.0))
-        if self.use_nn:
+        if self.use_nn or self.use_lateral_jerk:
           actual_curvature_rate = -VM.calc_curvature(math.radians(CS.steeringRateDeg), CS.vEgo, 0.0)
           actual_lateral_jerk = actual_curvature_rate * CS.vEgo ** 2
       else:
@@ -145,6 +143,21 @@ class LatControlTorque(LatControl):
       low_speed_factor = (self.lowspeed_factor_factor * interp(CS.vEgo, LOW_SPEED_X, LOW_SPEED_Y if not self.use_nn else LOW_SPEED_Y_NN))**2
       setpoint = desired_lateral_accel + low_speed_factor * desired_curvature
       measurement = actual_lateral_accel + low_speed_factor * actual_curvature
+      
+      if self.use_nn or self.use_lateral_jerk:
+        # prepare "look-ahead" desired lateral jerk
+        lookahead = interp(CS.vEgo, self.friction_look_ahead_bp, self.friction_look_ahead_v)
+        friction_upper_idx = next((i for i, val in enumerate(ModelConstants.T_IDXS) if val > lookahead), 16)
+        desired_curvature_rate = (interp(0.4, ModelConstants.T_IDXS[:CONTROL_N], lat_plan.curvatures) - interp(0.1, ModelConstants.T_IDXS[:CONTROL_N], lat_plan.curvatures)) / 0.3
+        lookahead_curvature_rate = get_lookahead_value(list(lat_plan.curvatureRates)[LAT_PLAN_MIN_IDX:friction_upper_idx], desired_curvature_rate)
+        lookahead_lateral_jerk = lookahead_curvature_rate * CS.vEgo**2
+        lat_accel_friction_factor = self.lat_accel_friction_factor
+        if self.use_steering_angle or lookahead_lateral_jerk == 0.0:
+          lookahead_lateral_jerk = 0.0
+          actual_lateral_jerk = 0.0
+          lat_accel_friction_factor = 1.0
+        lateral_jerk_setpoint = self.lat_jerk_friction_factor * lookahead_lateral_jerk
+        lateral_jerk_measurement = self.lat_jerk_friction_factor * actual_lateral_jerk
 
       model_planner_good = None not in [lat_plan, model_data] and all([len(i) >= CONTROL_N for i in [model_data.orientation.x, lat_plan.curvatures]])
       if self.use_nn and model_planner_good:
@@ -155,12 +168,6 @@ class LatControlTorque(LatControl):
         self.roll_deque.append(roll)
         self.lateral_accel_desired_deque.append(desired_lateral_accel)
 
-        # prepare "look-ahead" desired lateral jerk
-        lookahead = interp(CS.vEgo, self.friction_look_ahead_bp, self.friction_look_ahead_v)
-        friction_upper_idx = next((i for i, val in enumerate(ModelConstants.T_IDXS) if val > lookahead), 16)
-        lookahead_curvature_rate = get_lookahead_value(list(lat_plan.curvatureRates)[LAT_PLAN_MIN_IDX:friction_upper_idx], desired_curvature_rate)
-        lookahead_lateral_jerk = lookahead_curvature_rate * CS.vEgo**2
-
         # prepare past and future values
         # adjust future times to account for longitudinal acceleration
         adjusted_future_times = [t + 0.5*CS.aEgo*(t/max(CS.vEgo, 1.0)) for t in self.nn_future_times]
@@ -168,13 +175,6 @@ class LatControlTorque(LatControl):
         future_rolls = [roll_pitch_adjust(interp(t, ModelConstants.T_IDXS, model_data.orientation.x) + roll, interp(t, ModelConstants.T_IDXS, model_data.orientation.y) + pitch) for t in adjusted_future_times]
         past_lateral_accels_desired = [self.lateral_accel_desired_deque[min(len(self.lateral_accel_desired_deque)-1, i)] for i in self.history_frame_offsets]
         future_planned_lateral_accels = [interp(t, ModelConstants.T_IDXS[:CONTROL_N], lat_plan.curvatures) * CS.vEgo ** 2 for t in adjusted_future_times]
-
-        # compute NN error response.
-        lookahead_lateral_jerk = apply_deadzone(lookahead_lateral_jerk, self.lat_jerk_deadzone)
-        lateral_jerk_setpoint = self.lat_jerk_friction_factor * lookahead_lateral_jerk
-        lateral_jerk_measurement = self.lat_jerk_friction_factor * actual_lateral_jerk
-        if self.use_steering_angle or lookahead_lateral_jerk == 0.0:
-          lateral_jerk_measurement = 0.0
 
         # compute NNFF error response
         nnff_setpoint_input = [CS.vEgo, setpoint, lateral_jerk_setpoint, roll] \
@@ -204,13 +204,18 @@ class LatControlTorque(LatControl):
         nn_log = nn_input + nnff_setpoint_input + nnff_measurement_input
       else:
         gravity_adjusted_lateral_accel = desired_lateral_accel - params.roll * ACCELERATION_DUE_TO_GRAVITY
-        torque_from_setpoint = self.torque_from_lateral_accel(setpoint, self.torque_params, setpoint,
-                                                      lateral_accel_deadzone, friction_compensation=False)
-        torque_from_measurement = self.torque_from_lateral_accel(measurement, self.torque_params, measurement,
-                                                      lateral_accel_deadzone, friction_compensation=False)
+        torque_from_setpoint = self.torque_from_lateral_accel(setpoint, self.torque_params, lateral_jerk_setpoint,
+                                                      lateral_accel_deadzone, friction_compensation=self.use_lateral_jerk)
+        torque_from_measurement = self.torque_from_lateral_accel(measurement, self.torque_params, lateral_jerk_measurement,
+                                                      lateral_accel_deadzone, friction_compensation=self.use_lateral_jerk)
         pid_log.error = torque_from_setpoint - torque_from_measurement
+        error = desired_lateral_accel - actual_lateral_accel
+        if self.use_lateral_jerk:
+          friction_input = lat_accel_friction_factor * error + self.lat_jerk_friction_factor * lookahead_lateral_jerk
+        else:
+          friction_input = error
         ff = self.torque_from_lateral_accel(gravity_adjusted_lateral_accel, self.torque_params,
-                                            desired_lateral_accel - actual_lateral_accel,
+                                            friction_input,
                                             lateral_accel_deadzone, friction_compensation=True)
 
       freeze_integrator = steer_limited or CS.steeringPressed or CS.vEgo < 5

--- a/selfdrive/controls/lib/latcontrol_torque.py
+++ b/selfdrive/controls/lib/latcontrol_torque.py
@@ -143,6 +143,9 @@ class LatControlTorque(LatControl):
       setpoint = desired_lateral_accel + low_speed_factor * desired_curvature
       measurement = actual_lateral_accel + low_speed_factor * actual_curvature
       
+      lateral_jerk_setpoint = 0
+      lateral_jerk_measurement = 0
+      
       if self.use_nn or self.use_lateral_jerk:
         # prepare "look-ahead" desired lateral jerk
         lookahead = interp(CS.vEgo, self.friction_look_ahead_bp, self.friction_look_ahead_v)

--- a/selfdrive/controls/lib/latcontrol_torque.py
+++ b/selfdrive/controls/lib/latcontrol_torque.py
@@ -85,7 +85,6 @@ class LatControlTorque(LatControl):
 
     if self.use_nn:
       self.pitch = FirstOrderFilter(0.0, 0.5, 0.01)
-      self.lowspeed_factor_factor = 1.0
       # NN model takes current v_ego, lateral_accel, lat accel/jerk error, roll, and past/future/planned data
       # of lat accel and roll
       # Past value is computed using previous desired lat accel and observed roll
@@ -140,7 +139,7 @@ class LatControlTorque(LatControl):
       actual_lateral_accel = actual_curvature * CS.vEgo ** 2
       lateral_accel_deadzone = curvature_deadzone * CS.vEgo ** 2
 
-      low_speed_factor = (self.lowspeed_factor_factor * interp(CS.vEgo, LOW_SPEED_X, LOW_SPEED_Y if not self.use_nn else LOW_SPEED_Y_NN))**2
+      low_speed_factor = interp(CS.vEgo, LOW_SPEED_X, LOW_SPEED_Y if not self.use_nn else LOW_SPEED_Y_NN)**2
       setpoint = desired_lateral_accel + low_speed_factor * desired_curvature
       measurement = actual_lateral_accel + low_speed_factor * actual_curvature
       


### PR DESCRIPTION
Note the TODO comment where the option should be set based on a parameter in Lateral Tune settings. 

Also recall that the NNFF commits in FrogPilot currently have the effect of forcing use of the torque controller for all non-angle-control cars. 
* Forcing torque controller should be a separate toggle. 
* Enabling NNFF **or use of lateral jerk (this PR)** should also have the effect of forcing use of torque controller.