### PR TITLE
Add "soft" reboot button

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -251,6 +251,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"CustomTheme", PERSISTENT},
     {"DeviceShutdown", PERSISTENT},
     {"DisableOnroadUploads", PERSISTENT},
+    {"DoSoftReboot", CLEAR_ON_MANAGER_START},
     {"DriverCamera", PERSISTENT},
     {"DriveStats", PERSISTENT},
     {"EVTable", PERSISTENT},

--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -331,7 +331,7 @@ def manager_thread() -> None:
 
     # Exit main loop when uninstall/shutdown/reboot is needed
     shutdown = False
-    for param in ("DoUninstall", "DoShutdown", "DoReboot"):
+    for param in ("DoUninstall", "DoShutdown", "DoReboot", "DoSoftReboot"):
       if params.get_bool(param):
         shutdown = True
         params.put("LastManagerExitReason", f"{param} {datetime.datetime.now()}")
@@ -371,7 +371,9 @@ def main() -> None:
   elif params.get_bool("DoShutdown"):
     cloudlog.warning("shutdown")
     HARDWARE.shutdown()
-
+  elif params.get_bool("DoSoftReboot"):
+    cloudlog.warning("softreboot")
+    HARDWARE.soft_reboot()
 
 if __name__ == "__main__":
   unblock_stdout()

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -304,6 +304,11 @@ DevicePanel::DevicePanel(SettingsWindow *parent) : ListWidget(parent) {
   QHBoxLayout *power_layout = new QHBoxLayout();
   power_layout->setSpacing(30);
 
+  QPushButton *softreboot_btn = new QPushButton(tr("Soft Reboot"));
+  softreboot_btn->setObjectName("softreboot_btn");
+  power_layout->addWidget(softreboot_btn);
+  QObject::connect(softreboot_btn, &QPushButton::clicked, this, &DevicePanel::softreboot);
+
   QPushButton *reboot_btn = new QPushButton(tr("Reboot"));
   reboot_btn->setObjectName("reboot_btn");
   power_layout->addWidget(reboot_btn);
@@ -319,8 +324,10 @@ DevicePanel::DevicePanel(SettingsWindow *parent) : ListWidget(parent) {
   }
 
   setStyleSheet(R"(
-    #reboot_btn { height: 120px; border-radius: 15px; background-color: #393939; }
-    #reboot_btn:pressed { background-color: #4a4a4a; }
+    #softreboot_btn { height: 120px; border-radius: 15px; background-color: #e2e22c; }
+    #softreboot_btn:pressed { background-color: #ffe224; }  
+    #reboot_btn { height: 120px; border-radius: 15px; background-color: #e2872c; }
+    #reboot_btn:pressed { background-color: #ff9724; }
     #poweroff_btn { height: 120px; border-radius: 15px; background-color: #E22C2C; }
     #poweroff_btn:pressed { background-color: #FF2424; }
   )");
@@ -361,6 +368,18 @@ void DevicePanel::reboot() {
     }
   } else {
     ConfirmationDialog::alert(tr("Disengage to Reboot"), this);
+  }
+}
+
+void DevicePanel::softreboot() {
+  if (!uiState()->engaged()) {
+    if (ConfirmationDialog::confirm(tr("Are you sure you want to soft reboot?"), tr("Soft Reboot"), this)) {
+      if (!uiState()->engaged()) {
+        params.putBool("DoSoftReboot", true);
+      }
+    }
+  } else {
+    ConfirmationDialog::alert(tr("Disengage to Soft Reboot"), this);
   }
 }
 

--- a/selfdrive/ui/qt/offroad/settings.h
+++ b/selfdrive/ui/qt/offroad/settings.h
@@ -56,6 +56,7 @@ signals:
 private slots:
   void poweroff();
   void reboot();
+  void softreboot();
   void updateCalibDescription();
 
 private:

--- a/system/hardware/base.h
+++ b/system/hardware/base.h
@@ -26,6 +26,7 @@ public:
   }
 
   static void reboot() {}
+  static void soft_reboot() {}
   static void poweroff() {}
   static void set_brightness(int percent) {}
   static void set_display_power(bool on) {}

--- a/system/hardware/base.py
+++ b/system/hardware/base.py
@@ -31,6 +31,10 @@ class HardwareBase(ABC):
     pass
 
   @abstractmethod
+  def soft_reboot(self):
+    pass
+
+  @abstractmethod
   def uninstall(self):
     pass
 

--- a/system/hardware/tici/hardware.h
+++ b/system/hardware/tici/hardware.h
@@ -50,6 +50,7 @@ public:
   }
 
   static void reboot() { std::system("sudo reboot"); }
+  static void soft_reboot() { std::system("sudo systemctl restart comma"); }
   static void poweroff() { std::system("sudo poweroff"); }
   static void set_brightness(int percent) {
     std::string max = util::read_file("/sys/class/backlight/panel0-backlight/max_brightness");

--- a/system/hardware/tici/hardware.py
+++ b/system/hardware/tici/hardware.py
@@ -134,6 +134,9 @@ class Tici(HardwareBase):
   def reboot(self, reason=None):
     subprocess.check_output(["sudo", "reboot"])
 
+  def soft_reboot(self):
+    os.system("sudo systemctl restart comma")
+
   def uninstall(self):
     Path("/data/__system_reset__").touch()
     os.sync()


### PR DESCRIPTION
Adds a "soft" reboot button to the Devices panel. Restarts only openpilot which is faster than a full hardware reboot. It's implemented the same way as the standard reboot function, so it can easily be called in place of it elsewhere in the code where a full hardware reboot is unnecessary (i.e. after settings changes that trigger a reboot prompt). Also has the benefit of not killing any open SSH sessions like a normal reboot would.