### PR TITLE
fixed: ScreenRecorder sometimes make the 0 length viedo file.

### DIFF
--- a/selfdrive/frogpilot/screenrecorder/screenrecorder.cc
+++ b/selfdrive/frogpilot/screenrecorder/screenrecorder.cc
@@ -102,7 +102,7 @@ void ScreenRecorder::start() {
 }
 
 void ScreenRecorder::encoding_thread_func() {
-  const uint64_t start_time = nanos_since_boot() - 1;
+  const uint64_t start_time = nanos_since_boot();
   while (recording && encoder) {
     QImage popImage;
     if (image_queue.pop_wait_for(popImage, std::chrono::milliseconds(10))) {
@@ -123,11 +123,12 @@ void ScreenRecorder::stop() {
 
   recording = false;
   update();
-  closeEncoder();
-  image_queue.clear();
+
   if (encoding_thread.joinable()) {
     encoding_thread.join();
   }
+  closeEncoder();
+  image_queue.clear();
 }
 
 void ScreenRecorder::update_screen() {


### PR DESCRIPTION
call closeEncoder, after all encoding threads are joined.


refer from : https://github.com/jc01rho-openpilot-BoltEV2019-KoKr/boltpilot/blob/0ba0f16cdd0bd13432bac2a915e71efeebc5c3b0/selfdrive/ui/qt/screenrecorder/screenrecorder.cc#L176