### PR TITLE
Round SLC for Initial Set

### DIFF
--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -167,7 +167,7 @@ class VCruiseHelper:
       # Initial set speed
       if desired_speed_limit != 0 and frogpilot_variables.set_speed_limit:
         # If there's a known speed limit and the corresponding FP toggle is set, push it to the car
-        self.v_cruise_kph = desired_speed_limit * CV.MS_TO_KPH
+        self.v_cruise_kph = int(round(desired_speed_limit * CV.MS_TO_KPH))
       else:
         # Use fixed initial set speed from mode etc.
         self.v_cruise_kph = int(round(clip(CS.vEgo * CV.MS_TO_KPH, initial, V_CRUISE_MAX)))


### PR DESCRIPTION
When using SLC for setting max speed in combination with short press for nearest 5 mph increment, the first button press does not always "work" after engaging.

This is due to SLC speed not being round. For example, when SLC is 50 mph, it sets v_cruise_kph to 80.4672 kph. Then a decel press run this logic CRUISE_NEAREST_FUNC[button_type](self.v_cruise_kph / v_cruise_delta) * v_cruise_delta -> math.floor((80.4672/(1.6*5)))*(1.6*5) which returns 80 kph which becomes the new v_cruise_kph. 

So, old of 80.4672 kph and new of 80 kph both round to 50 mph so nothing changes in the UI or significant enough to notice in speed.

This fix causing the initial v_cruise_kph to set to 80 kph retaining nominal operation afterword for this example.

![image](https://github.com/FrogAi/FrogPilot/assets/76917194/cd00e30c-b08f-4d04-82fb-c5ebba82a7b2)
