### PR TITLE
GM: Keep single_pedal_mode true when Regen paddle pressed

### DIFF
--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -90,7 +90,7 @@ class CarState(CarStateBase):
     # Regen braking is braking
     if self.CP.transmissionType == TransmissionType.direct:
       ret.regenBraking = pt_cp.vl["EBCMRegenPaddle"]["RegenPaddle"] != 0
-      self.single_pedal_mode = ret.gearShifter == GearShifter.low or pt_cp.vl["EVDriveMode"]["SinglePedalModeActive"] == 1
+      self.single_pedal_mode = ret.gearShifter == GearShifter.low or pt_cp.vl["EVDriveMode"]["SinglePedalModeActive"] == 1 or (ret.regenBraking and GearShifter.manumatic)
 
     if self.CP.enableGasInterceptor:
       ret.gas = (pt_cp.vl["GAS_SENSOR"]["INTERCEPTOR_GAS"] + pt_cp.vl["GAS_SENSOR"]["INTERCEPTOR_GAS2"]) / 2.


### PR DESCRIPTION
When the regen paddle is pressed, manual mode also goes true. This causes the "Shift to L" error message the frame before OP disengages. This PR removes that error.

<img width="376" alt="Screenshot 2024-04-14 at 3 19 00 PM" src="https://github.com/FrogAi/FrogPilot/assets/76917194/603d2dc7-0e55-4b2d-ac89-8c2326820173">
</br>
<img width="358" alt="Screenshot 2024-04-14 at 3 19 50 PM" src="https://github.com/FrogAi/FrogPilot/assets/76917194/fca5c594-83bb-479a-844c-43d3e75ef7b6">
