### PR TITLE
Display auto tune values in the onroad UI

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -385,6 +385,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"SetSpeedLimit", PERSISTENT},
     {"SetSpeedOffset", PERSISTENT},
     {"SilentMode", PERSISTENT},
+    {"ShowAutoTune", PERSISTENT},
     {"ShowCPU", PERSISTENT},
     {"ShowGPU", PERSISTENT},
     {"ShowIP", PERSISTENT},

--- a/selfdrive/frogpilot/ui/visual_settings.cc
+++ b/selfdrive/frogpilot/ui/visual_settings.cc
@@ -35,6 +35,7 @@ FrogPilotVisualsPanel::FrogPilotVisualsPanel(SettingsWindow *parent) : FrogPilot
     {"LeadInfo", "Lead Info and Logics", "Get detailed information about the vehicle ahead, including speed and distance, and the logic behind your following distance.", ""},
     {"PedalsOnUI", "Pedals Being Pressed", "Display which pedals are being pressed on the onroad UI below the steering wheel icon.", ""},
     {"RoadNameUI", "Road Name", "See the name of the road you're on at the bottom of your screen. Sourced from OpenStreetMap.", ""},
+    {"ShowAutoTune", "Auto Tune Values", "Display the live lateral acceleration factor and friction coefficient in the onroad UI.", ""},
 
     {"DriverCamera", "Driver Camera On Reverse", "Show the driver's camera feed when you shift to reverse.", "../assets/img_driver_face_static.png"},
 

--- a/selfdrive/frogpilot/ui/visual_settings.h
+++ b/selfdrive/frogpilot/ui/visual_settings.h
@@ -32,7 +32,7 @@ private:
 
   std::set<QString> alertVolumeControlKeys = {"EngageVolume", "DisengageVolume", "RefuseVolume", "PromptVolume", "PromptDistractedVolume", "WarningSoftVolume", "WarningImmediateVolume"};
   std::set<QString> customAlertsKeys = {"GreenLightAlert", "LeadDepartingAlert", "LoudBlindspotAlert", "SpeedLimitChangedAlert"};
-  std::set<QString> customOnroadUIKeys = {"AccelerationPath", "AdjacentPath", "BlindSpotPath", "FPSCounter", "LeadInfo", "PedalsOnUI", "RoadNameUI"};
+  std::set<QString> customOnroadUIKeys = {"AccelerationPath", "AdjacentPath", "BlindSpotPath", "FPSCounter", "LeadInfo", "PedalsOnUI", "RoadNameUI", "ShowAutoTune"};
   std::set<QString> customThemeKeys = {"HolidayThemes", "CustomColors", "CustomIcons", "CustomSignals", "CustomSounds"};
   std::set<QString> modelUIKeys = {"DynamicPathWidth", "HideLeadMarker", "LaneLinesWidth", "PathEdgeWidth", "PathWidth", "RoadEdgesWidth", "UnlimitedLength"};
   std::set<QString> qolKeys = {"DriveStats", "FullMap", "HideSpeed", "MapStyle", "WheelSpeed"};

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -1339,6 +1339,10 @@ void AnnotatedCameraWidget::updateFrogPilotWidgets(QPainter &p) {
   turnSignalLeft = scene.turn_signal_left;
   turnSignalRight = scene.turn_signal_right;
 
+  showTune = scene.show_tune;
+  latAccel = scene.lat_accel;
+  friction = scene.friction;
+
   if (!(showDriverCamera || fullMapOpen)) {
     if (leadInfo) {
       drawLeadInfo(p);
@@ -1660,6 +1664,38 @@ void AnnotatedCameraWidget::drawLeadInfo(QPainter &p) {
   drawText(followText, Qt::white);
 
   p.restore();
+
+  if (showTune) {
+    p.save();
+    int tuningRectWidth = rect().width() / 2;
+    int tuningRectX = rect().left() - 1 + (rect().width() - tuningRectWidth) / 2;
+    QRect tuningRect(tuningRectX, rect().top() + adjustedRect.height() - 60, tuningRectWidth, 40);
+    p.setBrush(QColor(0, 0, 0, 150));
+    p.drawRoundedRect(tuningRect, 30, 30);
+    p.setFont(InterFont(30, QFont::DemiBold));
+    p.setRenderHint(QPainter::TextAntialiasing);
+
+    QRect tuningRectAdj = tuningRect.adjusted(0, 27, 0, 27);
+    int tuneTextBaseLine = tuningRectAdj.y() + p.fontMetrics().height() / 2 - p.fontMetrics().descent() - 5;
+
+    QString latAccelText = (mapOpen ? "Lat. Accel.: " : "Lateral Acceleration: ") + QString::number(latAccel, 'f', 3);
+    QString frictionText = (mapOpen ? " | Fric. " : " | Friction: ")  + QString::number(friction, 'f', 3);
+    
+    int tuneTextWidth = p.fontMetrics().horizontalAdvance(latAccelText)
+                      + p.fontMetrics().horizontalAdvance(frictionText);
+    int tuneTextStart = tuningRectAdj.x() + (tuningRectAdj.width() - tuneTextWidth) / 2;
+
+    auto drawTuneText = [&](const QString &text, const QColor color) {
+      p.setPen(color);
+      p.drawText(tuneTextStart, tuneTextBaseLine, text);
+      tuneTextStart += p.fontMetrics().horizontalAdvance(text);
+    };
+
+    drawTuneText(latAccelText, Qt::white);
+    drawTuneText(frictionText, Qt::white);
+
+    p.restore();
+  }
 }
 
 PedalIcons::PedalIcons(QWidget *parent) : QWidget(parent), scene(uiState()->scene) {

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -273,6 +273,25 @@ void OnroadWindow::paintEvent(QPaintEvent *event) {
 
     update();
   }
+  
+  // Draw auto tune parameters
+  if (scene.show_tune) {
+    QString tuneDisplayString = QString("Lateral Acceleration: %1 | Friction: %2")
+      .arg(scene.lat_accel, 0, 'f', 3))
+      .arg(scene.friction, 0, 'f', 3));
+
+    p.setFont(InterFont(30, QFont::DemiBold));
+    p.setRenderHint(QPainter::TextAntialiasing);
+    p.setPen(Qt::white);
+
+    QRect currentRect = rect();
+    int tuneWidth = p.fontMetrics().horizontalAdvance(tuneDisplayString);
+    int tuneX = (currentRect.width() - tuneWidth) / 2;
+    int tuneY = currentRect.top() + 27;
+
+    p.drawText(tuneX, tuneY, tuneDisplayString);
+    update();
+  }
 }
 
 void OnroadWindow::updateFPSCounter() {
@@ -1339,10 +1358,6 @@ void AnnotatedCameraWidget::updateFrogPilotWidgets(QPainter &p) {
   turnSignalLeft = scene.turn_signal_left;
   turnSignalRight = scene.turn_signal_right;
 
-  showTune = scene.show_tune;
-  latAccel = scene.lat_accel;
-  friction = scene.friction;
-
   if (!(showDriverCamera || fullMapOpen)) {
     if (leadInfo) {
       drawLeadInfo(p);
@@ -1664,38 +1679,6 @@ void AnnotatedCameraWidget::drawLeadInfo(QPainter &p) {
   drawText(followText, Qt::white);
 
   p.restore();
-
-  if (showTune) {
-    p.save();
-    int tuningRectWidth = rect().width() / 2;
-    int tuningRectX = rect().left() - 1 + (rect().width() - tuningRectWidth) / 2;
-    QRect tuningRect(tuningRectX, rect().top() + adjustedRect.height() - 60, tuningRectWidth, 40);
-    p.setBrush(QColor(0, 0, 0, 150));
-    p.drawRoundedRect(tuningRect, 30, 30);
-    p.setFont(InterFont(30, QFont::DemiBold));
-    p.setRenderHint(QPainter::TextAntialiasing);
-
-    QRect tuningRectAdj = tuningRect.adjusted(0, 37, 0, 37);
-    int tuneTextBaseLine = tuningRectAdj.y() + p.fontMetrics().height() / 2 - p.fontMetrics().descent() - 20;
-
-    QString latAccelText = (mapOpen ? "Lat. Accel.: " : "Lateral Acceleration: ") + QString::number(latAccel, 'f', 3);
-    QString frictionText = (mapOpen ? " | Fric.: " : " | Friction: ")  + QString::number(friction, 'f', 3);
-    
-    int tuneTextWidth = p.fontMetrics().horizontalAdvance(latAccelText)
-                      + p.fontMetrics().horizontalAdvance(frictionText);
-    int tuneTextStart = tuningRectAdj.x() + (tuningRectAdj.width() - tuneTextWidth) / 2;
-
-    auto drawTuneText = [&](const QString &text, const QColor color) {
-      p.setPen(color);
-      p.drawText(tuneTextStart, tuneTextBaseLine, text);
-      tuneTextStart += p.fontMetrics().horizontalAdvance(text);
-    };
-
-    drawTuneText(latAccelText, Qt::white);
-    drawTuneText(frictionText, Qt::white);
-
-    p.restore();
-  }
 }
 
 PedalIcons::PedalIcons(QWidget *parent) : QWidget(parent), scene(uiState()->scene) {

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -1676,10 +1676,10 @@ void AnnotatedCameraWidget::drawLeadInfo(QPainter &p) {
     p.setRenderHint(QPainter::TextAntialiasing);
 
     QRect tuningRectAdj = tuningRect.adjusted(0, 27, 0, 27);
-    int tuneTextBaseLine = tuningRectAdj.y() + p.fontMetrics().height() / 2 - p.fontMetrics().descent() - 5;
+    int tuneTextBaseLine = tuningRectAdj.y() + p.fontMetrics().height() / 2 - p.fontMetrics().descent() - 8;
 
     QString latAccelText = (mapOpen ? "Lat. Accel.: " : "Lateral Acceleration: ") + QString::number(latAccel, 'f', 3);
-    QString frictionText = (mapOpen ? " | Fric. " : " | Friction: ")  + QString::number(friction, 'f', 3);
+    QString frictionText = (mapOpen ? " | Fric.: " : " | Friction: ")  + QString::number(friction, 'f', 3);
     
     int tuneTextWidth = p.fontMetrics().horizontalAdvance(latAccelText)
                       + p.fontMetrics().horizontalAdvance(frictionText);

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -1675,8 +1675,8 @@ void AnnotatedCameraWidget::drawLeadInfo(QPainter &p) {
     p.setFont(InterFont(30, QFont::DemiBold));
     p.setRenderHint(QPainter::TextAntialiasing);
 
-    QRect tuningRectAdj = tuningRect.adjusted(0, 27, 0, 27);
-    int tuneTextBaseLine = tuningRectAdj.y() + p.fontMetrics().height() / 2 - p.fontMetrics().descent() - 8;
+    QRect tuningRectAdj = tuningRect.adjusted(0, 37, 0, 37);
+    int tuneTextBaseLine = tuningRectAdj.y() + p.fontMetrics().height() / 2 - p.fontMetrics().descent() - 20;
 
     QString latAccelText = (mapOpen ? "Lat. Accel.: " : "Lateral Acceleration: ") + QString::number(latAccel, 'f', 3);
     QString frictionText = (mapOpen ? " | Fric.: " : " | Friction: ")  + QString::number(friction, 'f', 3);

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -226,6 +226,7 @@ private:
   bool roadNameUI;
   bool showDriverCamera;
   bool showSLCOffset;
+  bool showTune;
   bool slcOverridden;
   bool speedLimitController;
   bool turnSignalLeft;
@@ -235,8 +236,10 @@ private:
 
   float cruiseAdjustment;
   float distanceConversion;
+  float friction;
   float laneWidthLeft;
   float laneWidthRight;
+  float latAccel;
   float slcSpeedLimit;
   float slcSpeedLimitOffset;
   float speedConversion;

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -226,7 +226,6 @@ private:
   bool roadNameUI;
   bool showDriverCamera;
   bool showSLCOffset;
-  bool showTune;
   bool slcOverridden;
   bool speedLimitController;
   bool turnSignalLeft;
@@ -236,10 +235,8 @@ private:
 
   float cruiseAdjustment;
   float distanceConversion;
-  float friction;
   float laneWidthLeft;
   float laneWidthRight;
-  float latAccel;
   float slcSpeedLimit;
   float slcSpeedLimitOffset;
   float speedConversion;

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -296,6 +296,11 @@ static void update_state(UIState *s) {
     float scale = (cam_state.getSensor() == cereal::FrameData::ImageSensor::AR0231) ? 6.0f : 1.0f;
     scene.light_sensor = std::max(100.0f - scale * cam_state.getExposureValPercent(), 0.0f);
   }
+  if (sm.updated("liveTorqueParameters")) {
+    auto torque_params = sm["liveTorqueParameters"].getLiveTorqueParameters();
+    scene.lat_accel = torque_params.getLatAccelFactorFiltered();
+    scene.friction = torque_params.getFrictionCoefficientFiltered();
+  }
   scene.started = sm["deviceState"].getDeviceState().getStarted() && scene.ignition;
 
   scene.world_objects_visible = scene.world_objects_visible ||
@@ -338,6 +343,7 @@ void ui_update_frogpilot_params(UIState *s) {
   scene.use_si = scene.lead_info && params.getBool("UseSI");
   scene.pedals_on_ui = custom_onroad_ui && params.getBool("PedalsOnUI");
   scene.road_name_ui = custom_onroad_ui && params.getBool("RoadNameUI");
+  scene.show_tune = custom_onroad_ui && params.getBool("ShowAutoTune");
 
   bool custom_theme = params.getBool("CustomTheme");
   scene.custom_colors = custom_theme ? params.getInt("CustomColors") : 0;
@@ -434,7 +440,7 @@ UIState::UIState(QObject *parent) : QObject(parent) {
     "modelV2", "controlsState", "liveCalibration", "radarState", "deviceState",
     "pandaStates", "carParams", "driverMonitoringState", "carState", "liveLocationKalman", "driverStateV2",
     "wideRoadCameraState", "managerState", "navInstruction", "navRoute", "uiPlan",
-    "frogpilotCarControl", "frogpilotDeviceState", "frogpilotPlan",
+    "frogpilotCarControl", "frogpilotDeviceState", "frogpilotPlan", "liveTorqueParameters",
   });
 
   Params params;

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -222,6 +222,7 @@ typedef struct UIScene {
   bool show_driver_camera;
   bool show_slc_offset;
   bool show_slc_offset_ui;
+  bool show_tune;
   bool speed_limit_changed;
   bool speed_limit_controller;
   bool speed_limit_overridden;
@@ -239,9 +240,11 @@ typedef struct UIScene {
 
   float acceleration;
   float adjusted_cruise;
+  float friction;
   float lane_line_width;
   float lane_width_left;
   float lane_width_right;
+  float lat_accel;
   float path_edge_width;
   float path_width;
   float road_edge_width;
@@ -271,7 +274,8 @@ typedef struct UIScene {
   int steering_angle_deg;
   int stopped_equivalence;
   int wheel_icon;
-
+  
+  
   QPolygonF track_adjacent_vertices[6];
   QPolygonF track_edge_vertices;
 


### PR DESCRIPTION
Displays the live lateral acceleration factor and friction coefficient values above the top metrics. Toggle is in the Custom Onroad UI settings page.
