### PR TITLE
Update HyundaiCanFD dash icons

### DIFF
--- a/selfdrive/car/hyundai/hyundaicanfd.py
+++ b/selfdrive/car/hyundai/hyundaicanfd.py
@@ -41,7 +41,7 @@ def create_steering_messages(packer, CP, CAN, enabled, lat_active, apply_steer):
 
   values = {
     "LKA_MODE": 2,
-    "LKA_ICON": 2 if lat_active else 1,
+    "LKA_ICON": 2 if enabled else 1 if lat_active else 0 # HDA2
     "TORQUE_REQUEST": apply_steer,
     "LKA_ASSIST": 0,
     "STEER_REQ": 1 if lat_active else 0,
@@ -116,7 +116,7 @@ def create_acc_cancel(packer, CP, CAN, cruise_info_copy):
 def create_lfahda_cluster(packer, CAN, enabled, lat_active):
   values = {
     "HDA_ICON": 1 if enabled else 0,
-    "LFA_ICON": 2 if lat_active else 0,
+    "LFA_ICON": 2 if enabled else 1 if lat_active else 0, # HDA1
   }
   return packer.make_can_msg("LFAHDA_CLUSTER", CAN.ECAN, values)
 


### PR DESCRIPTION
Updated hyundaicanfd create_lfahda_cluster (hda1) and create_steering_messages (hda2) such that the LKA icon is green on engaged, gray on lateral only, and blank on disengaged.