### PR TITLE
navd: allow the mapbox host to be configured via an environment variable

### DIFF
--- a/selfdrive/navd/navd.py
+++ b/selfdrive/navd/navd.py
@@ -62,7 +62,7 @@ class RouteEngine:
       self.mapbox_host = "https://api.mapbox.com"
     else:
       self.api = Api(self.params.get("DongleId", encoding='utf8'))
-      self.mapbox_host = os.getenv('COMMA_MAPS_HOST', 'https://maps.comma.ai')
+      self.mapbox_host = os.getenv('MAPS_HOST', 'https://maps.comma.ai')
 
     # FrogPilot variables
     self.frogpilot_toggles = FrogPilotVariables.toggles

--- a/selfdrive/navd/navd.py
+++ b/selfdrive/navd/navd.py
@@ -62,7 +62,7 @@ class RouteEngine:
       self.mapbox_host = "https://api.mapbox.com"
     else:
       self.api = Api(self.params.get("DongleId", encoding='utf8'))
-      self.mapbox_host = "https://maps.comma.ai"
+      self.mapbox_host = os.getenv('COMMA_MAPS_HOST', 'https://maps.comma.ai')
 
     # FrogPilot variables
     self.frogpilot_toggles = FrogPilotVariables.toggles


### PR DESCRIPTION
This seems to be the only hard-coded Comma host in the code. Athena and the API can be set with `ATHENA_HOST` and `API_HOST` variables, as seen at the following lines. In addition, there is one other place where this is _not_ hard-coded. This change just maintains environment variable parity

- https://github.com/FrogAi/FrogPilot/blob/5551c51ca3913b3b68d1547f5011605401c9ae16/selfdrive/ui/qt/maps/map_helpers.h#L18

- https://github.com/FrogAi/FrogPilot/blob/c9289bef84aab5105da740ffd6c40f3f41530759/system/athena/athenad.py#L44

- https://github.com/FrogAi/FrogPilot/blob/c9289bef84aab5105da740ffd6c40f3f41530759/common/api/__init__.py#L8

`navd` is also removed in the upstream, or I'd have pursued this patch there. Will FrogPilot be removing it as well?