### PR TITLE
HKG - Enable AOL via LKAS

### DIFF
--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -25,7 +25,7 @@ struct FrogPilotCarState @0xaedffd8f31e7b55d {
     }
   }
 
-  alwaysOnLateralDisabled @0 :Bool;
+  alwaysOnLateralEnabled @0 :Bool;
   brakeLights @1 :Bool;
   dashboardSpeedLimit @2 :Float32;
   distanceLongPressed @3 :Bool;

--- a/panda/board/main.c
+++ b/panda/board/main.c
@@ -223,7 +223,7 @@ void tick_handler(void) {
       }
 
       // exit controls allowed if unused by openpilot for a few seconds
-      if (controls_allowed && !heartbeat_engaged) {
+      if ((controls_allowed || aol_allowed) && !(heartbeat_engaged || (alternative_experience & ALT_EXP_ALWAYS_ON_LATERAL))) {
         heartbeat_engaged_mismatches += 1U;
         if (heartbeat_engaged_mismatches >= 3U) {
           controls_allowed = false;

--- a/panda/board/safety.h
+++ b/panda/board/safety.h
@@ -354,6 +354,7 @@ int set_safety_hooks(uint16_t mode, uint16_t param) {
   reset_sample(&torque_driver);
   reset_sample(&angle_meas);
 
+  aol_allowed = false;
   controls_allowed = false;
   relay_malfunction_reset();
   safety_rx_checks_invalid = false;
@@ -552,7 +553,6 @@ bool steer_torque_cmd_checks(int desired_torque, int steer_req, const SteeringLi
   bool violation = false;
   uint32_t ts = microsecond_timer_get();
 
-  bool aol_allowed = acc_main_on && (alternative_experience & ALT_EXP_ALWAYS_ON_LATERAL);
   if (controls_allowed) {
     // acc main must be on if controls are allowed
     acc_main_on = controls_allowed;
@@ -642,7 +642,6 @@ bool steer_torque_cmd_checks(int desired_torque, int steer_req, const SteeringLi
 // Safety checks for angle-based steering commands
 bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const SteeringLimits limits) {
   bool violation = false;
-  bool aol_allowed = acc_main_on && (alternative_experience & ALT_EXP_ALWAYS_ON_LATERAL);
   if (controls_allowed) {
     // acc main must be on if controls are allowed
     acc_main_on = controls_allowed;

--- a/panda/board/safety/safety_hyundai.h
+++ b/panda/board/safety/safety_hyundai.h
@@ -180,6 +180,14 @@ static void hyundai_rx_hook(const CANPacket_t *to_push) {
       update_sample(&torque_driver, torque_driver_new);
     }
 
+    bool lkas_button = false;
+    if (addr == 0x391) {
+      lkas_button = GET_BIT(to_push, 4U);
+      if (alternative_experience & ALT_EXP_ALWAYS_ON_LATERAL) {
+        hyundai_lkas_button_check(lkas_button);
+      }
+    }
+
     // ACC steering wheel buttons
     if (addr == 0x4F1) {
       int cruise_button = GET_BYTE(to_push, 0) & 0x7U;

--- a/panda/board/safety/safety_hyundai_common.h
+++ b/panda/board/safety/safety_hyundai_common.h
@@ -90,6 +90,13 @@ void hyundai_common_cruise_buttons_check(const int cruise_button, const bool mai
   }
 }
 
+void hyundai_lkas_button_check(const bool lkas_pressed) {
+  if ((lkas_pressed && !lkas_pressed_prev) && (alternative_experience & ALT_EXP_ALWAYS_ON_LATERAL)) {
+    aol_allowed = true;
+  }
+  lkas_pressed_prev = lkas_pressed;
+}
+
 uint32_t hyundai_common_canfd_compute_checksum(const CANPacket_t *to_push) {
   int len = GET_LEN(to_push);
   uint32_t address = GET_ADDR(to_push);

--- a/panda/board/safety_declarations.h
+++ b/panda/board/safety_declarations.h
@@ -227,6 +227,8 @@ bool acc_main_on = false;  // referred to as "ACC off" in ISO 15622:2018
 int cruise_button_prev = 0;
 int cruise_main_prev = 0;
 bool safety_rx_checks_invalid = false;
+bool aol_allowed = false;
+bool lkas_pressed_prev = false;
 
 // for safety modes with torque steering control
 int desired_torque_last = 0;       // last desired steer torque

--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -58,7 +58,9 @@ class CarState(CarStateBase):
     self.active_mode = 0
     self.drive_mode_prev = 0
 
-  # Traffic signals for Speed Limit Controller - Credit goes to Multikyd!
+    self.lkas_previously_enabled = False
+
+# Traffic signals for Speed Limit Controller - Credit goes to Multikyd!
   def calculate_speed_limit(self, cp, cp_cam):
     if self.CP.carFingerprint in CANFD_CAR:
       speed_limit_bus = cp if self.CP.flags & HyundaiFlags.CANFD_HDA2 else cp_cam

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -176,6 +176,8 @@ class CarInterface(CarInterfaceBase):
         *create_button_events(self.CS.cruise_buttons[-1], self.CS.prev_cruise_buttons, BUTTONS_DICT),
         *create_button_events(self.CS.lkas_enabled, self.CS.lkas_previously_enabled, {1: FrogPilotButtonType.lkas}),
       ]
+    else:
+      ret.buttonEvents = create_button_events(self.CS.lkas_enabled, self.CS.lkas_previously_enabled, {1: FrogPilotButtonType.lkas})
 
     # On some newer model years, the CANCEL button acts as a pause/resume button based on the PCM state
     # To avoid re-engaging when openpilot cancels, check user engagement intention via buttons

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -237,7 +237,7 @@ class CarInterfaceBase(ABC):
     self.use_nnff = not comma_nnff_supported and nnff_supported and lateral_tune and self.params.get_bool("NNFF")
     self.use_nnff_lite = not self.use_nnff and lateral_tune and self.params.get_bool("NNFFLite")
 
-    self.always_on_lateral_disabled = False
+    self.always_on_lateral_enabled = False
     self.belowSteerSpeed_shown = False
     self.disable_belowSteerSpeed = False
     self.disable_resumeRequired = False
@@ -419,7 +419,7 @@ class CarInterfaceBase(ABC):
       ret.cruiseState.speedCluster = ret.cruiseState.speed
 
     # Add any additional frogpilotCarStates
-    fp_ret.alwaysOnLateralDisabled = self.always_on_lateral_disabled
+    fp_ret.alwaysOnLateralEnabled = self.always_on_lateral_enabled
     fp_ret.distanceLongPressed = self.frogpilot_distance_functions(frogpilot_toggles)
     fp_ret.ecoGear |= ret.gearShifter == GearShifter.eco
     fp_ret.sportGear |= ret.gearShifter == GearShifter.sport
@@ -481,7 +481,7 @@ class CarInterfaceBase(ABC):
 
       # FrogPilot button presses
       if b.type == FrogPilotButtonType.lkas and b.pressed:
-        self.always_on_lateral_disabled = not self.always_on_lateral_disabled
+        self.always_on_lateral_enabled = not self.always_on_lateral_enabled
 
     # Handle permanent and temporary steering faults
     self.steering_unpressed = 0 if cs_out.steeringPressed else self.steering_unpressed + 1

--- a/selfdrive/frogpilot/controls/frogpilot_planner.py
+++ b/selfdrive/frogpilot/controls/frogpilot_planner.py
@@ -69,12 +69,14 @@ class FrogPilotPlanner:
     if frogpilot_toggles.openpilot_longitudinal:
       self.frogpilot_acceleration.update(controlsState, frogpilotCarState, v_cruise, v_ego, frogpilot_toggles)
 
-    self.always_on_lateral_active |= frogpilot_toggles.always_on_lateral_main or carState.cruiseState.enabled
-    self.always_on_lateral_active &= frogpilot_toggles.always_on_lateral and carState.cruiseState.available
+    self.always_on_lateral_active |= (frogpilot_toggles.always_on_lateral_main or carState.cruiseState.enabled) or \
+                                      frogpilot_toggles.always_on_lateral_lkas
+    self.always_on_lateral_active &= frogpilot_toggles.always_on_lateral
     self.always_on_lateral_active &= driving_gear
     self.always_on_lateral_active &= self.lateral_check
-    self.always_on_lateral_active &= not (frogpilot_toggles.always_on_lateral_lkas and frogpilotCarState.alwaysOnLateralDisabled)
     self.always_on_lateral_active &= not (carState.brakePressed and v_ego < frogpilot_toggles.always_on_lateral_pause_speed) or carState.standstill
+    self.always_on_lateral_active &= (frogpilot_toggles.always_on_lateral_lkas and frogpilotCarState.alwaysOnLateralEnabled) or \
+                                     (frogpilot_toggles.always_on_lateral_main and carState.cruiseState.available)
 
     run_cem = frogpilot_toggles.conditional_experimental_mode or frogpilot_toggles.force_stops or frogpilot_toggles.green_light_alert or frogpilot_toggles.show_stopping_point
     if run_cem and (controlsState.enabled or self.always_on_lateral_active) and driving_gear:


### PR DESCRIPTION
Opening a new PR - the PR branch was force-pushed so I couldn't reopen the original.

Enables the ability to activate Always On Lateral by pressing the LKAS button with Cruise Main off for HKG vehicles.

With AOL toggled on under Controls and:

- Enable on Cruise Main off + Control via LKAS off = AOL enagages only when long is engaged
- Enable on Cruise Main off + Control via LKAS on = AOL can be toggled on and off via LKAS regardless of Cruise Main state
- Enable on Cruise Main on + Control via LKAS on = same as above, but AOL will be engaged any time Cruise Main is on regardless of LKAS state
- Enable on Cruise Main on + Control via LKAS off = LKAS has no effect on AOL, AOL is engaged any time Cruise Main is on

Works for both openpilot and stock longitudinal.

The CAN support commit is currently untested and optional - can be left out for HKG CAN-FD support only for now, if desired.
