### PR TITLE
fixed: update_translations.py should cover the FrogPilot ui

### DIFF
--- a/selfdrive/ui/update_translations.py
+++ b/selfdrive/ui/update_translations.py
@@ -6,6 +6,7 @@ import os
 from openpilot.common.basedir import BASEDIR
 
 UI_DIR = os.path.join(BASEDIR, "selfdrive", "ui")
+FROG_UI_DIR = os.path.join(BASEDIR, "selfdrive", "frogpilot", "ui")
 TRANSLATIONS_DIR = os.path.join(UI_DIR, "translations")
 LANGUAGES_FILE = os.path.join(TRANSLATIONS_DIR, "languages.json")
 TRANSLATIONS_INCLUDE_FILE = os.path.join(TRANSLATIONS_DIR, "alerts_generated.h")
@@ -33,7 +34,7 @@ def update_translations(vanish: bool = False, translation_files: None | list[str
 
   for file in translation_files:
     tr_file = os.path.join(translations_dir, f"{file}.ts")
-    args = f"lupdate -locations none -recursive {UI_DIR} -ts {tr_file} -I {BASEDIR}"
+    args = f"lupdate -locations none -recursive {UI_DIR} {FROG_UI_DIR} -ts {tr_file} -I {BASEDIR}"
     if vanish:
       args += " -no-obsolete"
     if file in PLURAL_ONLY:


### PR DESCRIPTION
when you add the translate for FrogPilot specific string to "selfdrive/ui/translations/*.ts"

the "update_translations.py" does not cover the strings in "selfdrive/frogpilot/ui" 
(which is wrapped by tr("blabla"),


so fixed. :)