### PR TITLE
Increase Allowable QLog Size for Uploader

### DIFF
--- a/system/loggerd/uploader.py
+++ b/system/loggerd/uploader.py
@@ -27,7 +27,11 @@ NetworkType = log.DeviceState.NetworkType
 UPLOAD_ATTR_NAME = 'user.upload'
 UPLOAD_ATTR_VALUE = b'1'
 
-UPLOAD_QLOG_QCAM_MAX_SIZE = 5 * 1e6  # MB
+MAX_UPLOAD_SIZES = {
+  "qlog": 25*1e6,  # can't be too restrictive here since we use qlogs to find
+                   # bugs, including ones that can cause massive log sizes
+  "qcam": 5*1e6,
+}
 
 allow_sleep = bool(os.getenv("UPLOADER_SLEEP", "1"))
 force_wifi = os.getenv("FORCEWIFI") is not None
@@ -174,7 +178,7 @@ class Uploader:
     if sz == 0:
       # tag files of 0 size as uploaded
       success = True
-    elif name in self.immediate_priority and sz > UPLOAD_QLOG_QCAM_MAX_SIZE:
+    elif name in MAX_UPLOAD_SIZES and sz > MAX_UPLOAD_SIZES[name]:
       cloudlog.event("uploader_too_large", key=key, fn=fn, sz=sz)
       success = True
     else:


### PR DESCRIPTION
This is cherrypicked from commaai/openpilot@c287232

The uploader limits the size of uploaded logs.  The size is calculated prior to compression. Before Nov 25, 2024 this was set at 5MB, comma has since increased this to 25MB since a potential bug could be one that causes very large log sizes.

If a log exceeds this limit, the uploader outputs an error, but that error is not logged anywhere and would only be seen if tmux was running at the time the error occurred.  The log is then marked uploaded and never tried again.  Which makes tracking this down a little annoying.

When this happens the file list in user admin shows missing qlog files:
![image](https://github.com/user-attachments/assets/14e8500d-fc23-43b7-90dc-1ee66bfa1eba)


In my case, my logs were bloated because these logs contain a `git diff` output and all of the compiled translation files were appearing in the diff leading to about 1.75MB of additional logging details.  I will update my .gitignore file to fix this, but it seems reasonable to increase this limit if comma is as well and their logic for doing so seems rational.