### PR TITLE
TSK Keyboard using system keyboard

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -29,6 +29,10 @@ function agnos_init {
     fi
     $DIR/system/hardware/tici/updater $AGNOS_PY $MANIFEST
   fi
+
+  # Prepare /cache/params
+  sudo mkdir -p /cache/params || true
+  sudo chown comma:comma /cache/params
 }
 
 function launch {

--- a/selfdrive/ui/SConscript
+++ b/selfdrive/ui/SConscript
@@ -19,7 +19,7 @@ qt_env['CXXFLAGS'] += ["-Wno-deprecated-declarations"]
 
 qt_util = qt_env.Library("qt_util", ["#selfdrive/ui/qt/api.cc", "#selfdrive/ui/qt/util.cc"], LIBS=base_libs)
 widgets_src = ["ui.cc", "qt/widgets/input.cc", "qt/widgets/wifi.cc",
-               "qt/widgets/ssh_keys.cc", "qt/widgets/toggle.cc", "qt/widgets/controls.cc",
+               "qt/widgets/ssh_keys.cc", "qt/widgets/toggle.cc", "qt/widgets/tsk_keyboard.cc", "qt/widgets/controls.cc",
                "qt/widgets/offroad_alerts.cc", "qt/widgets/prime.cc", "qt/widgets/keyboard.cc",
                "qt/widgets/scrollview.cc", "qt/widgets/cameraview.cc", "#third_party/qrcode/QrCode.cc",
                "qt/request_repeater.cc", "qt/qt_window.cc", "qt/network/networking.cc", "qt/network/wifi_manager.cc"]

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -14,6 +14,7 @@
 #include "selfdrive/ui/qt/widgets/prime.h"
 #include "selfdrive/ui/qt/widgets/scrollview.h"
 #include "selfdrive/ui/qt/widgets/ssh_keys.h"
+#include "selfdrive/ui/qt/widgets/tsk_keyboard.h"
 
 #include "selfdrive/frogpilot/ui/qt/offroad/frogpilot_settings.h"
 
@@ -211,6 +212,7 @@ DevicePanel::DevicePanel(SettingsWindow *parent) : ListWidget(parent) {
   setSpacing(50);
   addItem(new LabelControl(tr("Dongle ID"), getDongleId().value_or(tr("N/A"))));
   addItem(new LabelControl(tr("Serial"), params.get("HardwareSerial").c_str()));
+  addItem(new TSKKeyboard());
 
   pair_device = new ButtonControl(tr("Pair Device"), tr("PAIR"),
                                   tr("Pair your device with comma connect (connect.comma.ai) and claim your comma prime offer."));

--- a/selfdrive/ui/qt/widgets/tsk_keyboard.cc
+++ b/selfdrive/ui/qt/widgets/tsk_keyboard.cc
@@ -1,0 +1,112 @@
+#include "selfdrive/ui/qt/widgets/tsk_keyboard.h"
+
+#include "common/params.h"
+#include "selfdrive/ui/qt/api.h"
+#include "selfdrive/ui/qt/widgets/input.h"
+
+TSKKeyboard::TSKKeyboard() :
+  ButtonControl("TSK Keyboard (tap to see installed)", "INSTALL", "") {
+
+  QObject::connect(this, &ButtonControl::clicked, [=]() {
+    setEnabled(false);
+
+    QString installed = QString::fromStdString(params.get("SecOCKey"));
+    QString archived = getArchive("/cache/params/SecOCKey");
+    if (!archived.length()) {
+      // Old location
+      archived = getArchive("/persist/tsk/key");
+    }
+
+    QString defaultText = "";
+    if (installed.length()) {
+      // Currently installed is the preferred default text
+      defaultText = installed;
+    } else if (archived.length()) {
+      // Else, use the archived key if exists
+      defaultText = archived;
+    }
+
+    // Show the archived key as a hint
+    QString subtitle = "";
+    if (archived.length()) {
+      subtitle = QString("Archived key: ") +  archived;
+    }
+
+    QString key = InputDialog::getText("Enter your Toyota Security Key", this, subtitle, false, 32, defaultText);
+    if (key.length() != 0) {
+      if (isValid(key)) {
+        params.put("SecOCKey", key.toStdString());
+
+        // Write to /cache/params/SecOCKey
+        QFile keyFile("/cache/params/SecOCKey");
+        // Assume /cache/params exists and is owned by comma (handled in launch_openpilot.sh)
+        if (keyFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+          QTextStream out(&keyFile);
+          out << key;
+          keyFile.close();
+        } else {
+          // This is a bonus feature, so stay silent if it fails
+        }
+
+        ConfirmationDialog::alert(tr("Success!\nRestart comma to have openpilot use the key"), this);
+      } else {
+        ConfirmationDialog::alert(tr("Invalid key: %1").arg(key), this);
+      }
+    }
+
+    refresh(); // Live update
+  });
+
+  refresh(); // Initial draw
+}
+
+void TSKKeyboard::refresh() {
+  QString key = QString::fromStdString(params.get("SecOCKey"));
+  if (!key.length()) {
+    key = "Not Installed";
+  }
+  setDescription(key);
+  setEnabled(true);
+}
+
+QString TSKKeyboard::getArchive(QString filePath) {
+  QFile archiveFile(filePath);
+
+  // Archived key file doesn't exist
+  if (!archiveFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    return "";
+  }
+
+  QTextStream in(&archiveFile);
+  QString key = in.readAll();
+  archiveFile.close();
+
+  // Archived key file can't be read
+  if (in.status() != QTextStream::Ok) {
+    return "";
+  }
+
+  // Archived key is not a valid key
+  if (!isValid(key)) {
+    return "";
+  }
+
+  // Return the key
+  return key;
+}
+
+// Check if the key is a 32 characters long hexadecimal string
+bool TSKKeyboard::isValid(QString key) {
+  if (key.length() != 32) {
+    return false;
+  }
+
+  // Check if each character is a valid hexadecimal digit (0-9, a-f)
+  for (QChar c : key) {
+    if (!c.isDigit() && !(c.isLower() && c >= 'a' && c <= 'f')) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/selfdrive/ui/qt/widgets/tsk_keyboard.h
+++ b/selfdrive/ui/qt/widgets/tsk_keyboard.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QPushButton>
+#include <QFile>
+
+#include "system/hardware/hw.h"
+
+#ifdef SUNNYPILOT
+#include "selfdrive/ui/sunnypilot/qt/widgets/controls.h"
+#define ButtonControl ButtonControlSP
+#define ToggleControl ToggleControlSP
+#else
+#include "selfdrive/ui/qt/widgets/controls.h"
+#endif
+
+class TSKKeyboard : public ButtonControl {
+  Q_OBJECT
+
+public:
+  TSKKeyboard();
+
+private:
+  Params params;
+
+  QString getArchive(QString);
+  bool isValid(QString);
+  void refresh();
+};


### PR DESCRIPTION
This keyboard allows TSK vehicle users to verify the currently installed key and also type in the key if it's missing.

Experienced users can use SSH to do the same without this PR, but this allows newbies to do this without using SSH.

This will make it easier to have TSK vehicle owners to easily switch to FrogPilot.

Paired with https://github.com/commaai/openpilot/pull/34401/files

![image](https://github.com/user-attachments/assets/84dbaca2-4fa9-45e9-9f9c-1447432e4d70)
![image](https://github.com/user-attachments/assets/d41c2408-a01a-4d46-9012-9c0c23e91a59)
