### PR TITLE
Keep current speed limit value after override and use the override/cruise value.

### DIFF
--- a/selfdrive/ui/qt/onroad/annotated_camera.cc
+++ b/selfdrive/ui/qt/onroad/annotated_camera.cc
@@ -71,7 +71,7 @@ void AnnotatedCameraWidget::updateState(int alert_height, const UIState &s) {
 
   auto speed_limit_sign = nav_instruction.getSpeedLimitSign();
   if (s.scene.show_speed_limits || s.scene.speed_limit_controller) {
-    speedLimit = slcOverridden ? s.scene.speed_limit_overridden_speed : s.scene.speed_limit;
+    speedLimit = s.scene.speed_limit;
   } else {
     speedLimit = nav_alive ? nav_instruction.getSpeedLimit() : 0.0;
   }


### PR DESCRIPTION
This will keep the OSM speed limit grayed out after override so you don't have it showing the same cruise speed, so instead of showing 55 cruise / 55 speed limit, we keep the speed limit grayed out as shown in the image.

![1f28e743-2093-46dd-b23a-63c3697fbc4d 2](https://github.com/user-attachments/assets/fff4675d-808a-4216-aee0-eebea00bab03)

