### PR TITLE
don't remount persist unnecessarily

### DIFF
--- a/selfdrive/frogpilot/frogpilot_functions.py
+++ b/selfdrive/frogpilot/frogpilot_functions.py
@@ -148,7 +148,6 @@ def frogpilot_boot_functions(build_metadata, params_cache):
   threading.Thread(target=backup_thread, daemon=True).start()
 
 def setup_frogpilot(build_metadata):
-  run_cmd(["sudo", "mount", "-o", "remount,rw", "/persist"], "Successfully remounted /persist as read-write", "Failed to remount /persist")
   run_cmd(["sudo", "chmod", "0777", "/cache"], "Successfully updated /cache permissions", "Failed to update /cache permissions")
 
   CRASHES_DIR.mkdir(parents=True, exist_ok=True)
@@ -190,33 +189,6 @@ def setup_frogpilot(build_metadata):
     run_cmd(["sudo", "mount", "-o", "remount,rw", "/"], "Successfully remounted / as read-write", "Failed to remount / as read-write")
     run_cmd(["sudo", "cp", frogpilot_boot_logo, boot_logo_location], "Successfully replaced boot logo", "Failed to replace boot logo")
     run_cmd(["sudo", "mount", "-o", f"remount,{stock_mount_options}", "/"], "Successfully restored stock mount options", "Failed to restore stock mount options")
-
-  persist_comma_path = Path("/persist/comma")
-  backup_comma_path = Path("/data/backup_comma")
-  if persist_comma_path.exists():
-    shutil.copytree(persist_comma_path, backup_comma_path, dirs_exist_ok=True)
-    print("Successfully backed up /persist/comma to /data/backup_comma")
-
-  persist_params_path = Path("/persist/params")
-  if persist_params_path.exists() and persist_params_path.is_dir():
-    shutil.rmtree(persist_params_path)
-    print("Successfully deleted /persist/params")
-
-  persist_tracking_path = Path("/persist/tracking")
-  if persist_tracking_path.exists() and persist_tracking_path.is_dir():
-    tracking_cache = Params("/cache/tracking")
-    tracking_persist = Params("/persist/tracking")
-
-    tracking_cache.put_float("FrogPilotDrives", tracking_persist.get_float("FrogPilotDrives"))
-    tracking_cache.put_float("FrogPilotKilometers", tracking_persist.get_float("FrogPilotKilometers"))
-    tracking_cache.put_float("FrogPilotMinutes", tracking_persist.get_float("FrogPilotMinutes"))
-
-    shutil.rmtree(persist_tracking_path)
-    print("Successfully deleted /persist/tracking")
-
-  if not persist_comma_path.exists():
-    shutil.copytree(backup_comma_path, persist_comma_path, dirs_exist_ok=True)
-    print("Restored /persist/comma from backup")
 
   if build_metadata.channel == "FrogPilot-Development" and Path("/persist/frogsgomoo.py").is_file():
     run_cmd(["sudo", "mount", "-o", "remount,rw", "/persist"], "Successfully remounted /persist as read-write", "Failed to remount /persist")


### PR DESCRIPTION
It seems like `/persist` isn't used any more now that things are moving to `/cache`, so there shouldn't be a need to remount it or create/restore backups?