### PR TITLE
fix nnff bug; nullify lateral jerk values if *not* using steer angle

### DIFF
--- a/selfdrive/controls/lib/latcontrol_torque.py
+++ b/selfdrive/controls/lib/latcontrol_torque.py
@@ -169,7 +169,7 @@ class LatControlTorque(LatControl):
         predicted_lateral_jerk = get_predicted_lateral_jerk(model_data.acceleration.y, self.t_diffs)
         desired_lateral_jerk = (interp(self.desired_lat_jerk_time, ModelConstants.T_IDXS, model_data.acceleration.y) - desired_lateral_accel) / self.desired_lat_jerk_time
         lookahead_lateral_jerk = get_lookahead_value(predicted_lateral_jerk[LAT_PLAN_MIN_IDX:friction_upper_idx], desired_lateral_jerk)
-        if self.use_steering_angle or lookahead_lateral_jerk == 0.0:
+        if not self.use_steering_angle or lookahead_lateral_jerk == 0.0:
           lookahead_lateral_jerk = 0.0
           actual_lateral_jerk = 0.0
           self.lat_accel_friction_factor = 1.0


### PR DESCRIPTION
This embarassing bug was removing NNFF's instantaneous lateral jerk input, and nullifying the effects of NNFF-lite. That's right, NNFF-lite users were experiencing the placebo effect for any change they experienced!

I drove on the same bugfix on my fork and NNFF is smoother entering/exiting curves now.