### PR TITLE
Feature request by Maximize0987, Larger lead metrics info

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -366,6 +366,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"LeadDepartingAlert", PERSISTENT},
     {"LeadDetectionThreshold", PERSISTENT},
     {"LeadInfo", PERSISTENT},
+    {"BigLeadInfo", PERSISTENT},
     {"LKASButtonControl", PERSISTENT},
     {"LockDoors", PERSISTENT},
     {"LockDoorsTimer", PERSISTENT},

--- a/frogpilot/common/frogpilot_variables.py
+++ b/frogpilot/common/frogpilot_variables.py
@@ -203,6 +203,7 @@ frogpilot_default_params: list[tuple[str, str | bytes, int]] = [
   ("LeadDepartingAlert", "0", 0),
   ("LeadDetectionThreshold", "35", 3),
   ("LeadInfo", "1", 2),
+  ("BigLeadInfo", "1", 2),
   ("LKASButtonControl", "5", 2),
   ("LockDoors", "1", 0),
   ("LockDoorsTimer", "0", 0),
@@ -619,6 +620,7 @@ class FrogPilotVariables:
     toggle.show_fps = developer_metrics and (params.get_bool("FPSCounter") if tuning_level >= level["FPSCounter"] else default.get_bool("FPSCounter")) or toggle.debug_mode
     toggle.adjacent_path_metrics = (developer_metrics and params.get_bool("AdjacentPathMetrics") if tuning_level >= level["AdjacentPathMetrics"] else default.get_bool("AdjacentPathMetrics")) or toggle.debug_mode
     toggle.lead_metrics = (developer_metrics and params.get_bool("LeadInfo") if tuning_level >= level["LeadInfo"] else default.get_bool("LeadInfo")) or toggle.debug_mode
+    toggle.big_lead_metrics = (developer_metrics and params.get_bool("BigLeadInfo") if tuning_level >= level["BigLeadInfo"] else default.get_bool("BigLeadInfo")) or toggle.debug_mode
     toggle.numerical_temp = developer_metrics and (params.get_bool("NumericalTemp") if tuning_level >= level["NumericalTemp"] else default.get_bool("NumericalTemp")) or toggle.debug_mode
     toggle.fahrenheit = toggle.numerical_temp and (params.get_bool("Fahrenheit") if tuning_level >= level["Fahrenheit"] else default.get_bool("Fahrenheit")) and not toggle.debug_mode
     toggle.sidebar_metrics = developer_metrics and (params.get_bool("SidebarMetrics") if tuning_level >= level["SidebarMetrics"] else default.get_bool("SidebarMetrics")) or toggle.debug_mode

--- a/frogpilot/ui/qt/offroad/visual_settings.cc
+++ b/frogpilot/ui/qt/offroad/visual_settings.cc
@@ -55,6 +55,7 @@ FrogPilotVisualsPanel::FrogPilotVisualsPanel(FrogPilotSettingsWindow *parent) : 
     {"DeveloperMetrics", tr("Developer Metrics"), tr("Performance data, sensor readings, and system metrics for debugging and optimizing openpilot."), ""},
     {"BorderMetrics", tr("Border Metrics"), tr("Metrics displayed around the border of the driving screen.<br><br><b>Blind Spot</b>: Turn the border red when a vehicle is detected in a blind spot<br><b>Steering Torque</b>: Highlight the border green to red in accordance to the amount of steering torque being used<br><b>Turn Signal</b>: Flash the border yellow when a turn signal is active"), ""},
     {"LeadInfo", tr("Lead Info"), tr("Metrics displayed under vehicle markers listing their distance and current speed."), ""},
+    {"BigLeadInfo", tr("Bigger Lead Info"), tr("Same metrics as lead info, but the text on display is bigger."), ""},
     {"FPSCounter", tr("FPS Display"), tr("Display the <b>Frames Per Second (FPS)</b> at the bottom of the driving screen."), ""},
     {"NumericalTemp", tr("Numerical Temperature Gauge"), tr("Use numerical temperature readings instead of status labels in the sidebar."), ""},
     {"SidebarMetrics", tr("Sidebar"), tr("Display system information (<b>CPU</b>, <b>GPU</b>, <b>RAM usage</b>, <b>IP address</b>, <b>device storage</b>) in the sidebar."), ""},
@@ -462,6 +463,10 @@ void FrogPilotVisualsPanel::updateToggles() {
     }
 
     if (key == "LeadInfo") {
+      setVisible &= hasOpenpilotLongitudinal;
+    }
+
+    if (key == "BigLeadInfo") {
       setVisible &= hasOpenpilotLongitudinal;
     }
 

--- a/frogpilot/ui/qt/offroad/visual_settings.h
+++ b/frogpilot/ui/qt/offroad/visual_settings.h
@@ -33,7 +33,7 @@ private:
 
   std::set<QString> advancedCustomOnroadUIKeys = {"HideAlerts", "HideLeadMarker", "HideMapIcon", "HideMaxSpeed", "HideSpeed", "HideSpeedLimit", "WheelSpeed"};
   std::set<QString> customOnroadUIKeys = {"AccelerationPath", "AdjacentPath", "BlindSpotPath", "Compass", "OnroadDistanceButton", "PedalsOnUI", "RotatingWheel"};
-  std::set<QString> developerMetricKeys = {"AdjacentPathMetrics", "BorderMetrics", "FPSCounter", "LeadInfo", "NumericalTemp", "SidebarMetrics", "UseSI"};
+  std::set<QString> developerMetricKeys = {"AdjacentPathMetrics", "BorderMetrics", "FPSCounter", "LeadInfo", "BigLeadInfo", "NumericalTemp", "SidebarMetrics", "UseSI"};
   std::set<QString> developerSidebarKeys = {"DeveloperSidebarMetric1", "DeveloperSidebarMetric2", "DeveloperSidebarMetric3", "DeveloperSidebarMetric4", "DeveloperSidebarMetric5", "DeveloperSidebarMetric6", "DeveloperSidebarMetric7"};
   std::set<QString> developerUIKeys = {"DeveloperMetrics", "DeveloperSidebar", "DeveloperWidgets"};
   std::set<QString> developerWidgetKeys = {"AdjacentLeadsUI", "RadarTracksUI", "ShowStoppingPoint"};

--- a/frogpilot/ui/qt/onroad/frogpilot_annotated_camera.cc
+++ b/frogpilot/ui/qt/onroad/frogpilot_annotated_camera.cc
@@ -532,10 +532,20 @@ void FrogPilotAnnotatedCameraWidget::paintLateralPaused(QPainter &p, FrogPilotUI
 }
 
 void FrogPilotAnnotatedCameraWidget::paintLeadMetrics(QPainter &p, bool adjacent, QPointF *chevron, const cereal::FrogPilotPlan::Reader &frogpilotPlan, const cereal::RadarState::LeadData::Reader &lead_data) {
+  // Access the FrogPilot toggles through the shared UI state
+  FrogPilotUIState &fs = *frogpilotUIState();
+  QJsonObject &frogpilot_toggles = fs.frogpilot_toggles;
+
   float leadDistance = lead_data.getDRel() + (adjacent ? fabs(lead_data.getYRel()) : 0);
   float leadSpeed = std::max(lead_data.getVLead(), 0.0f);
 
-  p.setFont(InterFont(35, QFont::Bold));
+  // Adjust text size based on toggle
+  if (frogpilot_toggles.value("big_lead_metrics").toBool()) {
+    p.setFont(InterFont(45, QFont::Bold));
+  } else {
+    p.setFont(InterFont(35, QFont::Bold));
+  }
+
   p.setPen(QPen(whiteColor()));
 
   QString text;


### PR DESCRIPTION
Conditional toggle, increase text of leadmetrics by 10pts, on road testing showed any bigger would cause the text field to clip.