### PR TITLE
Pause Steering Signal Delay - LateralResumeDelay

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -429,6 +429,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"PathEdgeWidth", PERSISTENT},
     {"PathWidth", PERSISTENT},
     {"PauseAOLOnBrake", PERSISTENT},
+    {"LateralResumeDelay", PERSISTENT},
     {"PauseLateralOnSignal", PERSISTENT},
     {"PauseLateralSpeed", PERSISTENT},
     {"PedalsOnUI", PERSISTENT},

--- a/frogpilot/common/frogpilot_variables.py
+++ b/frogpilot/common/frogpilot_variables.py
@@ -251,6 +251,7 @@ frogpilot_default_params: list[tuple[str, str | bytes, int]] = [
   ("PathWidth", "6.1", 2),
   ("PauseAOLOnBrake", "0", 2),
   ("PauseLateralOnSignal", "0", 2),
+  ("LateralResumeDelay", "1", 2),
   ("PauseLateralSpeed", "0", 2),
   ("PedalsOnUI", "0", 2),
   ("PersonalizeOpenpilot", "1", 0),
@@ -802,6 +803,7 @@ class FrogPilotVariables:
     quality_of_life_lateral = params.get_bool("QOLLateral") if tuning_level >= level["QOLLateral"] else default.get_bool("QOLLateral")
     toggle.pause_lateral_below_speed = params.get_int("PauseLateralSpeed") * speed_conversion if quality_of_life_lateral and tuning_level >= level["PauseLateralSpeed"] else default.get_int("PauseLateralSpeed") * CV.MPH_TO_MS
     toggle.pause_lateral_below_signal = toggle.pause_lateral_below_speed != 0 and (params.get_bool("PauseLateralOnSignal") if tuning_level >= level["PauseLateralOnSignal"] else default.get_bool("PauseLateralOnSignal"))
+    toggle.pause_lateral_signal_delay = params.get_int("LateralResumeDelay") if tuning_level >= level["LateralResumeDelay"] else default.get_int("LateralResumeDelay")
 
     quality_of_life_longitudinal = params.get_bool("QOLLongitudinal") if tuning_level >= level["QOLLongitudinal"] else default.get_bool("QOLLongitudinal")
     toggle.custom_cruise_increase = params.get_int("CustomCruise") if quality_of_life_longitudinal and not pcm_cruise and tuning_level >= level["CustomCruise"] else default.get_int("CustomCruise")

--- a/frogpilot/ui/qt/offroad/lateral_settings.cc
+++ b/frogpilot/ui/qt/offroad/lateral_settings.cc
@@ -57,7 +57,7 @@ FrogPilotLateralPanel::FrogPilotLateralPanel(FrogPilotSettingsWindow *parent) : 
 
     {"QOLLateral", tr("Quality of Life"), tr("Miscellaneous features to improve the steering experience."), "../../frogpilot/assets/toggle_icons/quality_of_life.png"},
     {"PauseLateralSpeed", tr("Pause Steering Below"), tr("Temporarily pause steering control below the set speed."), ""},
-    {"LateralResumeDelay", tr("Pause Steering Signal Delay"), tr("Delay (in seconds) before steering resumes after the turn signal goes off, if below the 'Pause Steering Below' speed. Helps give time to manually straighten the wheel before lateral control resumes."), ""},
+    {"LateralResumeDelay", tr("Delay (in seconds) before lateral control resumes after the turn signal turns off, if the vehicle speed dropped below half of the 'Pause Steering Below' speed at any point while the turn signal was active. This helps give time to manually complete turns or slow-speed lane changes before steering control resumes."), ""},
 
     {"IgnoreMe", "Ignore Me", "This is simply used to fix the layout when the user opens the descriptions and the menu gets wonky. No idea why it happens, but I can't be asked to properly fix it so whatever. Sue me.", ""},
     {"IgnoreMe2", "Ignore Me", "This is simply used to fix the layout when the user opens the descriptions and the menu gets wonky. No idea why it happens, but I can't be asked to properly fix it so whatever. Sue me.", ""}

--- a/frogpilot/ui/qt/offroad/lateral_settings.cc
+++ b/frogpilot/ui/qt/offroad/lateral_settings.cc
@@ -57,7 +57,7 @@ FrogPilotLateralPanel::FrogPilotLateralPanel(FrogPilotSettingsWindow *parent) : 
 
     {"QOLLateral", tr("Quality of Life"), tr("Miscellaneous features to improve the steering experience."), "../../frogpilot/assets/toggle_icons/quality_of_life.png"},
     {"PauseLateralSpeed", tr("Pause Steering Below"), tr("Temporarily pause steering control below the set speed."), ""},
-    {"LateralResumeDelay", tr("Delay (in seconds) before lateral control resumes after the turn signal turns off, if the vehicle speed dropped below half of the 'Pause Steering Below' speed at any point while the turn signal was active. This helps give time to manually complete turns or slow-speed lane changes before steering control resumes."), ""},
+    {"LateralResumeDelay", tr("Pause Steering Signal Delay"), tr("Delay (in seconds) before lateral control resumes after the turn signal turns off, if the vehicle speed dropped below half of the 'Pause Steering Below' speed at any point while the turn signal was active. This helps give time to manually complete turns or slow-speed lane changes before steering control resumes."), ""},
 
     {"IgnoreMe", "Ignore Me", "This is simply used to fix the layout when the user opens the descriptions and the menu gets wonky. No idea why it happens, but I can't be asked to properly fix it so whatever. Sue me.", ""},
     {"IgnoreMe2", "Ignore Me", "This is simply used to fix the layout when the user opens the descriptions and the menu gets wonky. No idea why it happens, but I can't be asked to properly fix it so whatever. Sue me.", ""}

--- a/frogpilot/ui/qt/offroad/lateral_settings.cc
+++ b/frogpilot/ui/qt/offroad/lateral_settings.cc
@@ -57,6 +57,7 @@ FrogPilotLateralPanel::FrogPilotLateralPanel(FrogPilotSettingsWindow *parent) : 
 
     {"QOLLateral", tr("Quality of Life"), tr("Miscellaneous features to improve the steering experience."), "../../frogpilot/assets/toggle_icons/quality_of_life.png"},
     {"PauseLateralSpeed", tr("Pause Steering Below"), tr("Temporarily pause steering control below the set speed."), ""},
+    {"LateralResumeDelay", tr("Pause Steering Signal Delay"), tr("Delay (in seconds) before steering resumes after the turn signal goes off, if below the 'Pause Steering Below' speed. Helps give time to manually straighten the wheel before lateral control resumes."), ""},
 
     {"IgnoreMe", "Ignore Me", "This is simply used to fix the layout when the user opens the descriptions and the menu gets wonky. No idea why it happens, but I can't be asked to properly fix it so whatever. Sue me.", ""},
     {"IgnoreMe2", "Ignore Me", "This is simply used to fix the layout when the user opens the descriptions and the menu gets wonky. No idea why it happens, but I can't be asked to properly fix it so whatever. Sue me.", ""}
@@ -130,7 +131,8 @@ FrogPilotLateralPanel::FrogPilotLateralPanel(FrogPilotSettingsWindow *parent) : 
       std::vector<QString> pauseLateralToggles{"PauseLateralOnSignal"};
       std::vector<QString> pauseLateralToggleNames{"Turn Signal Only"};
       lateralToggle = new FrogPilotParamValueButtonControl(param, title, desc, icon, 0, 99, QString(), std::map<float, QString>(), 1, true, pauseLateralToggles, pauseLateralToggleNames, true);
-
+    } else if (param == "LateralResumeDelay") {
+          lateralToggle = new FrogPilotParamValueControl(param, title, desc, icon, 0, 5, QString(), std::map<float, QString>(), 1 );
     } else {
       lateralToggle = new ParamControl(param, title, desc, icon);
     }

--- a/frogpilot/ui/qt/offroad/lateral_settings.h
+++ b/frogpilot/ui/qt/offroad/lateral_settings.h
@@ -43,7 +43,7 @@ private:
   std::set<QString> aolKeys = {"AlwaysOnLateralLKAS", "AlwaysOnLateralMain", "PauseAOLOnBrake"};
   std::set<QString> laneChangeKeys = {"LaneChangeTime", "LaneDetectionWidth", "MinimumLaneChangeSpeed", "NudgelessLaneChange", "OneLaneChange"};
   std::set<QString> lateralTuneKeys = {"NNFF", "NNFFLite", "TurnDesires"};
-  std::set<QString> qolKeys = {"PauseLateralSpeed"};
+  std::set<QString> qolKeys = {"PauseLateralSpeed", "LateralResumeDelay"};
 
   std::set<QString> parentKeys;
 

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -203,6 +203,8 @@ class Controls:
 
     self.event_names_to_clear = set()
 
+    self.last_blinker_speed = 0
+
   def set_initial_state(self):
     if REPLAY:
       controls_state = self.params.get("ReplayControlsState")
@@ -618,10 +620,18 @@ class Controls:
     CC = car.CarControl.new_message()
     CC.enabled = self.enabled
 
+    # Check if lateral should be paused for blinker delay
+    lat_paused_for_blinker_delay = False
+    if self.frogpilot_toggles.pause_lateral_below_signal and not (CS.leftBlinker or CS.rightBlinker):
+      time_since_blinker = (self.sm.frame - self.last_blinker_frame) * DT_CTRL
+      if time_since_blinker < self.frogpilot_toggles.pause_lateral_signal_delay and self.last_blinker_speed < self.frogpilot_toggles.pause_lateral_below_speed:
+        lat_paused_for_blinker_delay = True
+
     # Check which actuators can be enabled
     standstill = CS.vEgo <= max(self.CP.minSteerSpeed, MIN_LATERAL_CONTROL_SPEED) or CS.standstill
     CC.latActive = (self.active or self.sm['frogpilotCarState'].alwaysOnLateralEnabled) and not CS.steerFaultTemporary and not CS.steerFaultPermanent and \
-                   (not standstill or self.joystick_mode) and self.sm['frogpilotPlan'].lateralCheck and not self.sm['frogpilotCarState'].pauseLateral
+                   (not standstill or self.joystick_mode) and self.sm['frogpilotPlan'].lateralCheck and not self.sm['frogpilotCarState'].pauseLateral and \
+                   (not lat_paused_for_blinker_delay)
     CC.longActive = self.enabled and not self.events.contains(ET.OVERRIDE_LONGITUDINAL) and not self.sm['frogpilotCarState'].pauseLongitudinal and self.CP.openpilotLongitudinalControl
 
     actuators = CC.actuators
@@ -633,6 +643,8 @@ class Controls:
       CC.rightBlinker = model_v2.meta.laneChangeDirection == LaneChangeDirection.right
 
     if CS.leftBlinker or CS.rightBlinker:
+      if not (self.CS_prev.leftBlinker or self.CS_prev.rightBlinker):
+        self.last_blinker_speed = CS.vEgo  # Record speed at activation
       self.last_blinker_frame = self.sm.frame
 
     # State specific actions

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -163,6 +163,7 @@ class Controls:
     self.personality = self.read_personality_param()
     self.v_cruise_helper = VCruiseHelper(self.CP)
     self.recalibrating_seen = False
+    self.blinker_min_speed = 0
 
     self.can_log_mono_time = 0
 
@@ -202,8 +203,6 @@ class Controls:
     self.has_menu = self.CP.carName == "gm" and not (self.CP.flags & GMFlags.NO_CAMERA.value or self.CP.carFingerprint in CC_ONLY_CAR)
 
     self.event_names_to_clear = set()
-
-    self.last_blinker_speed = 0
 
   def set_initial_state(self):
     if REPLAY:
@@ -624,7 +623,7 @@ class Controls:
     lat_paused_for_blinker_delay = False
     if self.frogpilot_toggles.pause_lateral_below_signal and not (CS.leftBlinker or CS.rightBlinker):
       time_since_blinker = (self.sm.frame - self.last_blinker_frame) * DT_CTRL
-      if time_since_blinker < self.frogpilot_toggles.pause_lateral_signal_delay and self.last_blinker_speed < self.frogpilot_toggles.pause_lateral_below_speed:
+      if time_since_blinker < self.frogpilot_toggles.pause_lateral_signal_delay and self.blinker_min_speed < self.frogpilot_toggles.pause_lateral_below_speed/2:
         lat_paused_for_blinker_delay = True
 
     # Check which actuators can be enabled
@@ -644,7 +643,9 @@ class Controls:
 
     if CS.leftBlinker or CS.rightBlinker:
       if not (self.CS_prev.leftBlinker or self.CS_prev.rightBlinker):
-        self.last_blinker_speed = CS.vEgo  # Record speed at activation
+        self.blinker_min_speed = CS.vEgo  # Initialize
+      else:
+        self.blinker_min_speed = min(self.blinker_min_speed, CS.vEgo)
       self.last_blinker_frame = self.sm.frame
 
     # State specific actions


### PR DESCRIPTION
Delay (in seconds) before steering resumes after the turn signal goes off, if below the 'Pause Steering Below' speed. Helps give time to manually straighten the wheel after turns, before lateral control resumes. 

Typical behavior (and limitation) of Hyundai LKA. Without this feature, it may feel like having two hands on the wheel when making turns. Made in reference with https://github.com/spektor56/ghostpilot/blob/b714177c27a60163f41d3290e8450b9099507b88/selfdrive/controls/controlsd.py#L617

Key addition is, it'll only apply under `PauseLateralSpeed`, to keep highway speed lane changes unchanged. And of course, the delay can be adjusted within FrogPilot settings for up to 5 seconds, instead of a hardcode. Has been tested to work.