### PR TITLE
add toggle for standby mode only when disengaged

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -513,6 +513,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"StandardJerkSpeedDecrease", PERSISTENT},
     {"StandardPersonalityProfile", PERSISTENT},
     {"StandbyMode", PERSISTENT},
+    {"StandbyModeOnlyWhenDisengaged", PERSISTENT},
     {"StartAccel", PERSISTENT},
     {"StartAccelStock", PERSISTENT},
     {"StartupMessageBottom", PERSISTENT},

--- a/frogpilot/common/frogpilot_variables.py
+++ b/frogpilot/common/frogpilot_variables.py
@@ -394,6 +394,7 @@ frogpilot_default_params: list[tuple[str, str | bytes, int, str]] = [
   ("StandardJerkSpeedDecrease", "100", 3, "100"),
   ("StandardPersonalityProfile", "1", 2, "0"),
   ("StandbyMode", "0", 2, "0"),
+  ("StandbyModeOnlyWhenDisengaged", "0", 2, "0"),
   ("StartAccel", "", 3, ""),
   ("StartAccelStock", "", 3, ""),
   ("StaticPedalsOnUI", "0", 2, "0"),
@@ -911,6 +912,7 @@ class FrogPilotVariables:
     toggle.driver_camera_in_reverse = quality_of_life_visuals and (params.get_bool("DriverCamera") if tuning_level >= level["DriverCamera"] else default.get_bool("DriverCamera"))
     toggle.onroad_distance_button = openpilot_longitudinal and (quality_of_life_visuals and (params.get_bool("OnroadDistanceButton") if tuning_level >= level["OnroadDistanceButton"] else default.get_bool("OnroadDistanceButton")) or toggle.debug_mode)
     toggle.standby_mode = quality_of_life_visuals and (params.get_bool("StandbyMode") if tuning_level >= level["StandbyMode"] else default.get_bool("StandbyMode"))
+    toggle.standby_mode_only_when_disengaged = toggle.standby_mode and (params.get_bool("StandbyModeOnlyWhenDisengaged") if tuning_level >= level["StandbyModeOnlyWhenDisengaged"] else default.get_bool("StandbyModeOnlyWhenDisengaged"))
     toggle.stopped_timer = quality_of_life_visuals and (params.get_bool("StoppedTimer") if tuning_level >= level["StoppedTimer"] else default.get_bool("StoppedTimer"))
 
     toggle.rainbow_path = params.get_bool("RainbowPath") if tuning_level >= level["RainbowPath"] else default.get_bool("RainbowPath")

--- a/frogpilot/ui/qt/offroad/visual_settings.cc
+++ b/frogpilot/ui/qt/offroad/visual_settings.cc
@@ -101,6 +101,7 @@ FrogPilotVisualsPanel::FrogPilotVisualsPanel(FrogPilotSettingsWindow *parent) : 
     {"CameraView", tr("Camera View"), tr("The active camera view display. This is purely a visual change and doesn't impact how openpilot drives!"), ""},
     {"DriverCamera", tr("Show Driver Camera When In Reverse"), tr("Display the driver camera feed when the vehicle is in reverse."), ""},
     {"StandbyMode", tr("Standby Mode"), tr("Turn the screen off when driving and automatically wake it up if engagement state changes or important alerts occur."), ""},
+    {"StandbyModeOnlyWhenDisengaged", tr("Only When Disengaged"), tr("Only allow the screen to sleep when openpilot is disengaged."), ""},
     {"StoppedTimer", tr("Stopped Timer"), tr("Replace the current speed with a timer when stopped to indicate how long the vehicle has been stopped for."), ""}
   };
 
@@ -322,6 +323,10 @@ FrogPilotVisualsPanel::FrogPilotVisualsPanel(FrogPilotSettingsWindow *parent) : 
       std::vector<QString> cameraOptions{tr("Auto"), tr("Driver"), tr("Standard"), tr("Wide")};
       ButtonParamControl *cameraSelection = new ButtonParamControl(param, title, desc, icon, cameraOptions);
       visualToggle = cameraSelection;
+    } else if (param == "StandbyMode") {
+      std::vector<QString> standbyToggles{"StandbyModeOnlyWhenDisengaged"};
+      std::vector<QString> standbyToggleNames{tr("Only When Disengaged")};
+      visualToggle = new FrogPilotButtonToggleControl(param, title, desc, icon, standbyToggles, standbyToggleNames);
 
     } else {
       visualToggle = new ParamControl(param, title, desc, icon);

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -424,7 +424,7 @@ void Device::updateBrightness(const UIState &s, const FrogPilotUIState &fs) {
     brightness = 0;
   } else if (s.scene.started && frogpilot_toggles.value("force_onroad").toBool()) {
     brightness = 100;
-  } else if (s.scene.started && frogpilot_toggles.value("standby_mode").toBool() && !frogpilot_scene.wake_up_screen && interactive_timeout == 0) {
+  } else if (s.scene.started && isStandbyModeEnabled(s, fs) && !frogpilot_scene.wake_up_screen && interactive_timeout == 0) {
     brightness = 0;
   } else if (s.scene.started && frogpilot_toggles.value("screen_brightness_onroad").toInt() != 101) {
     brightness = interactive_timeout > 0 ? fmax(5, frogpilot_toggles.value("screen_brightness_onroad").toInt()) : frogpilot_toggles.value("screen_brightness_onroad").toInt();
@@ -447,14 +447,14 @@ void Device::updateWakefulness(const UIState &s, const FrogPilotUIState &fs) {
   bool ignition_state_changed = s.scene.ignition != ignition_on;
   ignition_on = s.scene.ignition;
 
-  if (ignition_on && frogpilot_toggles.value("standby_mode").toBool()) {
+  if (ignition_on && isStandbyModeEnabled(s, fs)) {
     if (frogpilot_scene.wake_up_screen) {
       resetInteractiveTimeout(frogpilot_toggles.value("screen_timeout").toInt(), frogpilot_toggles.value("screen_timeout_onroad").toInt());
     }
   }
 
   if (ignition_state_changed) {
-    if (ignition_on && frogpilot_toggles.value("screen_brightness_onroad").toInt() == 0 && !frogpilot_toggles.value("standby_mode").toBool()) {
+    if (ignition_on && frogpilot_toggles.value("screen_brightness_onroad").toInt() == 0 && !isStandbyModeEnabled(s, fs)) {
       resetInteractiveTimeout(0, 0);
     } else {
       resetInteractiveTimeout(frogpilot_toggles.value("screen_timeout").toInt(), frogpilot_toggles.value("screen_timeout_onroad").toInt());
@@ -469,6 +469,13 @@ void Device::updateWakefulness(const UIState &s, const FrogPilotUIState &fs) {
 UIState *uiState() {
   static UIState ui_state;
   return &ui_state;
+}
+
+bool Device::isStandbyModeEnabled(const UIState &s, const FrogPilotUIState &fs) {
+  const QJsonObject &frogpilot_toggles = fs.frogpilot_toggles;
+  return frogpilot_toggles.value("standby_mode").toBool() &&
+         (!frogpilot_toggles.value("standby_mode_only_when_disengaged").toBool() ||
+          s.status == STATUS_DISENGAGED);
 }
 
 Device *device() {

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -186,6 +186,7 @@ private:
   void updateBrightness(const UIState &s, const FrogPilotUIState &fs);
   void updateWakefulness(const UIState &s, const FrogPilotUIState &fs);
   void setAwake(bool on);
+  bool isStandbyModeEnabled(const UIState &s, const FrogPilotUIState &fs);
 
 signals:
   void displayPowerChanged(bool on);


### PR DESCRIPTION
This adds a sub-toggle to `Standby Mode` that allows standby to be enabled only when controls are fully disengaged.

This allows the driver to ignore the Comma device when it is not in use. The device will wake up if/when OP controls are engaged.

This is my first PR, let me know if I'm doing something wrong.

<img width="1800" height="1000" alt="image" src="https://github.com/user-attachments/assets/cb09c1fe-289b-4d2e-8735-9230e0eea06d" />

I tested this on my personal fork this morning and it worked as I expected... the screen turned itself off after the timeout when no controls were engaged, but stayed awake when lat or lat/long were engaged. When the toggle is off, the old behavior was preserved.

I tried to take a screen recording but it appears the recording process keeps the screen awake.
