### PR TITLE
Honda: update format of HONDA_CLARITY torqueBP values from hexadecimal to decimal

### DIFF
--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -204,10 +204,10 @@ class CarInterface(CarInterfaceBase):
         for fw in car_fw:
           if fw.ecu == "eps" and b"-" not in fw.fwVersion and b"," in fw.fwVersion:
             ret.lateralTuning.pid.kf = 0.00004
-            ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 0xA00, 0x3C00], [0, 2560, 3840]]
+            ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 5760, 15360], [0, 2560, 3840]]
             ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.1575], [0.05175]]
           elif fw.ecu == "eps" and b"-" in fw.fwVersion and b"," in fw.fwVersion:
-            ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 0xA00, 0x2800], [0, 2560, 3840]]
+            ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 5760, 10240], [0, 2560, 3840]]
             ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.3], [0.1]]
       else:
         ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 2560], [0, 2560]]


### PR DESCRIPTION
Clarity torqueBP values were the only values in interface.py to be listed in hexadecimal. Values format changed to decimal. Evaluated values are unchanged. (0xA00 = 5760)

"Kiril — 9/16/2021 2:27 PM
It would be so much easier if people just used integers for both instead of hex"