### PR TITLE
Incorporate torque controller redundancy check in interfaces.py

### DIFF
--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -163,8 +163,8 @@ class CarInterfaceBase(ABC):
     ret.rotationalInertia = scale_rot_inertia(ret.mass, ret.wheelbase)
     ret.tireStiffnessFront, ret.tireStiffnessRear = scale_tire_stiffness(ret.mass, ret.wheelbase, ret.centerToFront, ret.tireStiffnessFactor)
 
-    # Enable torque controller for all cars that do not use angle based steering
-    if ret.steerControlType != car.CarParams.SteerControlType.angle and params.get_bool("LateralTune") and (params.get_bool("NNFF") or params.get_bool("NNFFLite")):
+    # Enable torque controller for all cars that do not use angle based steering and where torque controller is not already active
+    if ret.steerControlType != car.CarParams.SteerControlType.angle and params.get_bool("LateralTune") and (params.get_bool("NNFF") or params.get_bool("NNFFLite")) and ret.lateralTuning.which() != "torque":
       CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
 
     return ret


### PR DESCRIPTION
Add conditional logic to check if torque controller is already active before running configure_torque_tune

As it stands, if torque controller is enabled with custom parameters in selfdrive/car/brandname/interface.py, L168 will overwrite that activation with an activation of torque controller with standard parameters. This inflexibility hurts cars with multiple EPS FW, that require different parameters for differing levels of available steering wheel torque.

By adding this extra condition in the if statement, the code will respect an already active torque controller activation and will not try to overwrite it.