### PR TITLE
fix(navigation): load AMap JS SDK for Autocomplete search

### DIFF
--- a/frogpilot/system/the_pond/assets/components/navigation/navigation_destination.js
+++ b/frogpilot/system/the_pond/assets/components/navigation/navigation_destination.js
@@ -134,6 +134,44 @@ export function NavDestination() {
   const searchFieldState = reactive({ value: "" });
   const sessionToken = crypto.randomUUID?.() || Math.random().toString(36).slice(2);
 
+  let amapLoadPromise = null;
+
+  async function ensureAMapLoaded() {
+    if (amapLoadPromise) {
+      try {
+        return await amapLoadPromise;
+      } catch (e) {
+        // Previous load failed, reset and retry
+        amapLoadPromise = null;
+      }
+    }
+    
+    if (!state.amap1Key || !state.amap2Key) {
+      showSnackbar("AMap keys not configured", "error");
+      return null;
+    }
+    
+    // Set security config BEFORE loading SDK
+    window._AMapSecurityConfig = {
+      securityJsCode: state.amap2Key
+    };
+    
+    amapLoadPromise = AMapLoader.load({
+      key: state.amap1Key,
+      version: '2.0',
+      plugins: ['AMap.Autocomplete']
+    }).then(AMap => {
+      return AMap;
+    }).catch(e => {
+      console.error("Failed to load AMap SDK:", e);
+      showSnackbar("AMap search unavailable. Check your keys and network connection.", "error");
+      amapLoadPromise = null;
+      return null;
+    });
+    
+    return await amapLoadPromise;
+  }
+
   function areRoutesEqual(a, b) {
     return a?.routeHash && b?.routeHash && a.routeHash === b.routeHash;
   }
@@ -311,6 +349,8 @@ export function NavDestination() {
         const data = await res.json();
         state.suggestions = JSON.stringify(data.suggestions);
       } else {
+        const AMap = await ensureAMapLoaded();
+        if (!AMap) return;
         const auto = new AMap.Autocomplete({ city: "auto" });
         auto.search(val, (status, result) => {
           if (status === "complete" && result.tips) {
@@ -467,6 +507,8 @@ export function NavDestination() {
         const data = await res.json();
         state.suggestions = JSON.stringify(data.suggestions);
       } else {
+        const AMap = await ensureAMapLoaded();
+        if (!AMap) return;
         const auto = new AMap.Autocomplete({ city: "auto" });
         auto.search(val, (status, result) => {
           if (status === "complete" && result.tips) {

--- a/frogpilot/system/the_pond/templates/index.html
+++ b/frogpilot/system/the_pond/templates/index.html
@@ -37,6 +37,7 @@
     <script src="/assets/js/snackbar.js"></script>
 
     <script src="https://api.mapbox.com/mapbox-gl-js/v3.0.1/mapbox-gl.js"></script>
+    <script src="https://webapi.amap.com/loader.js"></script>
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary

The AMap (高德地图) JavaScript SDK is referenced in the navigation search code but was never loaded, causing `ReferenceError: AMap is not defined` when users toggle to the AMap search provider.

## Bug

`navigation_destination.js` calls `new AMap.Autocomplete()` in two places (`handleSearchKey` and `searchInput`) but the AMap JS SDK is never loaded — neither statically in `index.html` nor dynamically in JavaScript. This means AMap-based destination search is completely broken.

## Fix

**`index.html`** (+1 line):
- Added `<script src="https://webapi.amap.com/loader.js"></script>` to load the AMap JSAPI Loader

**`navigation_destination.js`** (+42 lines):
- Added `ensureAMapLoaded()` lazy-load singleton function that:
  - Configures `window._AMapSecurityConfig` with the user's security key (`AMapKey2`)
  - Calls `AMapLoader.load()` with the user's API key (`AMapKey1`), version `2.0`, and `AMap.Autocomplete` plugin
  - Caches the load promise to avoid redundant SDK loads
  - Handles errors with user-facing `showSnackbar()` feedback
- Updated both AMap search paths (`handleSearchKey` and `searchInput`) to `await ensureAMapLoaded()` before creating `Autocomplete` instances

## Testing

- Requires valid AMap API keys (Key #1 and Key #2) configured in device settings
- Toggle search provider to "Amap" and search for a destination
- Verify autocomplete suggestions appear
- Verify error message appears if keys are invalid or network is unavailable