### PR TITLE
fix: use_konik_server() falls back to persistent param

### DIFF
--- a/frogpilot/common/frogpilot_utilities.py
+++ b/frogpilot/common/frogpilot_utilities.py
@@ -489,7 +489,7 @@ def upload_toggles():
 
 @cache
 def use_konik_server():
-  return KONIK_PATH.is_file()
+  return KONIK_PATH.is_file() or params.get_bool("UseKonikServer")
 
 def wait_for_no_driver(sm, door_checks=False, time_threshold=60):
   can_parser = CANParser("toyota_nodsu_pt_generated", [("BODY_CONTROL_STATE", 3)], bus=0)


### PR DESCRIPTION
**Description**

`/cache` gets wiped on reboot so `/cache/use_konik` is gone before
registration runs. the toggle code recreates it but by then registration
already went down the wrong path and tried to hit the server.

if you don't have a sim card you get a 60 second "registering..." spinner
every single boot for no reason.

just falls back to the `UseKonikServer` param that's already persisted
in `/data/params/d/`.

**Change**

```python
# before
return KONIK_PATH.is_file()

# after
return KONIK_PATH.is_file() or params.get_bool("UseKonikServer")
```

**Verification**

tested on a device with no sim. no more "registering..." on boot.