### PR TITLE
loggerd: degrade gracefully on log storage failure instead of aborting

### DIFF
--- a/system/loggerd/bootlog.cc
+++ b/system/loggerd/bootlog.cc
@@ -52,8 +52,10 @@ int main(int argc, char** argv) {
   LOGW("bootlog to %s", path.c_str());
 
   // Open bootlog
-  bool r = util::create_directories(Path::log_root() + "/boot/", 0775);
-  assert(r);
+  if (!util::create_directories(Path::log_root() + "/boot/", 0775)) {
+    LOGE("bootlog: failed to create %s - skipping bootlog", (Path::log_root() + "/boot/").c_str());
+    return 0;
+  }
 
   ZstdFileWriter file(path, LOG_COMPRESSION_LEVEL);
   // Write initdata

--- a/system/loggerd/logger.cc
+++ b/system/loggerd/logger.cc
@@ -1,5 +1,7 @@
 #include "system/loggerd/logger.h"
 
+#include <cerrno>
+#include <cstring>
 #include <fstream>
 #include <map>
 #include <vector>
@@ -180,15 +182,28 @@ bool LoggerState::next() {
     std::remove(lock_file.c_str());
   }
 
+  // the segment counter advances even when storage is broken so we stay in
+  // sync with encoderd's segment rollover; a failed segment is simply a
+  // directory that never exists, and the next rotation retries from scratch.
   segment_path = route_path + "--" + std::to_string(++part);
-  bool ret = util::create_directories(segment_path, 0775);
-  assert(ret == true);
-
-  lock_file = segment_path + "/rlog.lock";
-  std::ofstream{lock_file};
+  if (!util::create_directories(segment_path, 0775)) {
+    LOGE("failed to create segment %s: %s - logging degraded", segment_path.c_str(), strerror(errno));
+    rlog.reset();
+    qlog.reset();
+    return false;
+  }
 
   rlog.reset(new ZstdFileWriter(segment_path + "/rlog.zst", LOG_COMPRESSION_LEVEL));
   qlog.reset(new ZstdFileWriter(segment_path + "/qlog.zst", LOG_COMPRESSION_LEVEL));
+  if (!rlog->ok() || !qlog->ok()) {
+    LOGE("failed to open log files in %s - logging degraded", segment_path.c_str());
+    rlog.reset();
+    qlog.reset();
+    return false;
+  }
+
+  lock_file = segment_path + "/rlog.lock";
+  std::ofstream{lock_file};
 
   // log init data & sentinel type.
   write(init_data.asBytes(), true);
@@ -197,6 +212,6 @@ bool LoggerState::next() {
 }
 
 void LoggerState::write(uint8_t* data, size_t size, bool in_qlog) {
-  rlog->write(data, size);
-  if (in_qlog) qlog->write(data, size);
+  if (rlog) rlog->write(data, size);
+  if (in_qlog && qlog) qlog->write(data, size);
 }

--- a/system/loggerd/logger.h
+++ b/system/loggerd/logger.h
@@ -20,6 +20,7 @@ public:
   bool next();
   void write(uint8_t* data, size_t size, bool in_qlog);
   inline int segment() const { return part; }
+  inline bool logging() const { return rlog != nullptr; }
   inline const std::string& segmentPath() const { return segment_path; }
   inline const std::string& routeName() const { return route_name; }
   inline void write(kj::ArrayPtr<kj::byte> bytes, bool in_qlog) { write(bytes.begin(), bytes.size(), in_qlog); }

--- a/system/loggerd/loggerd.cc
+++ b/system/loggerd/loggerd.cc
@@ -22,11 +22,17 @@ struct LoggerdState {
 };
 
 void logger_rotate(LoggerdState *s) {
-  bool ret =s->logger.next();
-  assert(ret);
+  bool ret = s->logger.next();
+  // reset the rotation state even on failure so the next attempt waits a full
+  // segment: one bounded retry per rotation instead of crashing (or spinning)
+  // when log storage fails (e.g. an ext4 read-only remount mid-drive)
   s->ready_to_rotate = 0;
   s->last_rotate_tms = millis_since_boot();
-  LOGW((s->logger.segment() == 0) ? "logging to %s" : "rotated to %s", s->logger.segmentPath().c_str());
+  if (ret) {
+    LOGW((s->logger.segment() == 0) ? "logging to %s" : "rotated to %s", s->logger.segmentPath().c_str());
+  } else {
+    LOGE("failed to create %s - logging degraded, will retry at next rotation", s->logger.segmentPath().c_str());
+  }
 }
 
 void rotate_if_needed(LoggerdState *s) {
@@ -79,7 +85,7 @@ size_t write_encode_data(LoggerdState *s, cereal::Event::Reader event, RemoteEnc
         LOGW("%s: dropped %d non iframe packets before init", encoder_info.publish_name, re.dropped_frames);
         re.dropped_frames = 0;
       }
-      if (encoder_info.record) {
+      if (encoder_info.record && re.writer) {
         // write the header
         auto header = edata.getHeader();
         re.writer->write((uint8_t *)header.begin(), header.size(), idx.getTimestampEof() / 1000, true, false);
@@ -137,16 +143,23 @@ int handle_encoder_msg(LoggerdState *s, Message *msg, std::string &name, struct 
       // if we aren't actually recording, don't create the writer
       if (encoder_info.record) {
         assert(encoder_info.filename != NULL);
-        re.writer.reset(new VideoWriter(s->logger.segmentPath().c_str(),
-                                        encoder_info.filename, idx.getType() != cereal::EncodeIndex::Type::FULL_H_E_V_C,
-                                        edata.getWidth(), edata.getHeight(), encoder_info.fps, idx.getType()));
+        if (s->logger.logging()) {
+          re.writer.reset(new VideoWriter(s->logger.segmentPath().c_str(),
+                                          encoder_info.filename, idx.getType() != cereal::EncodeIndex::Type::FULL_H_E_V_C,
+                                          edata.getWidth(), edata.getHeight(), encoder_info.fps, idx.getType()));
+        } else {
+          // log storage is degraded: no segment directory exists, so run this
+          // segment without a video writer and keep the encoder stream drained
+          re.writer.reset();
+        }
         re.recording = false;
         re.audio_initialized = false;
       }
       re.current_segment = s->logger.segment();
       re.marked_ready_to_rotate = false;
     }
-    if (re.audio_initialized || !encoder_info.include_audio) {
+    // without a writer there is no audio muxing to wait for
+    if (re.audio_initialized || !encoder_info.include_audio || !re.writer) {
       // we are in this segment now, process any queued messages before this one
       if (!re.q.empty()) {
         // Swap the queue out before iterating — recursive write_encode_data can push_back

--- a/system/loggerd/tests/test_logger.cc
+++ b/system/loggerd/tests/test_logger.cc
@@ -73,3 +73,23 @@ TEST_CASE("logger") {
     verify_segment(log_root + "/" + route_name, i, segment_cnt, 1);
   }
 }
+
+TEST_CASE("logger: degrades gracefully when log storage is broken") {
+  // a regular file as the parent makes create_directories fail with ENOTDIR,
+  // which (unlike permission-based setups) also fails when running as root
+  const std::string not_a_dir = "/tmp/test_logger_notdir";
+  system(("rm -rf " + not_a_dir + " && touch " + not_a_dir).c_str());
+  {
+    LoggerState logger(not_a_dir + "/realdata");
+    REQUIRE(!logger.next());
+    REQUIRE(!logger.logging());
+    // writes while degraded must be safe no-ops
+    write_msg(&logger);
+    // the segment counter keeps advancing so encoder sync is preserved
+    REQUIRE(logger.segment() == 0);
+    REQUIRE(!logger.next());
+    REQUIRE(logger.segment() == 1);
+    // destructor must not crash with no open segment
+  }
+  system(("rm -f " + not_a_dir).c_str());
+}

--- a/system/loggerd/video_writer.cc
+++ b/system/loggerd/video_writer.cc
@@ -1,4 +1,6 @@
 #include <cassert>
+#include <cerrno>
+#include <cstring>
 
 #include "system/loggerd/video_writer.h"
 #include "common/swaglog.h"
@@ -10,8 +12,12 @@ VideoWriter::VideoWriter(const char *path, const char *filename, bool remuxing, 
   lock_path = util::string_format("%s/%s.lock", path, filename);
 
   int lock_fd = HANDLE_EINTR(open(lock_path.c_str(), O_RDWR | O_CREAT, 0664));
-  assert(lock_fd >= 0);
-  close(lock_fd);
+  if (lock_fd >= 0) {
+    close(lock_fd);
+  } else {
+    // storage failure: carry on, the video file this lock guards won't exist either
+    LOGE("failed to create %s: %s", lock_path.c_str(), strerror(errno));
+  }
 
   LOGD("encoder_open %s remuxing:%d", this->vid_path.c_str(), this->remuxing);
   if (this->remuxing) {
@@ -41,11 +47,38 @@ VideoWriter::VideoWriter(const char *path, const char *filename, bool remuxing, 
     assert(this->out_stream);
 
     int err = avio_open(&this->ofmt_ctx->pb, this->vid_path.c_str(), AVIO_FLAG_WRITE);
-    assert(err >= 0);
+    if (err < 0) {
+      LOGE("failed to open %s (%d) - not recording", this->vid_path.c_str(), err);
+      disable();
+    }
 
   } else {
     this->of = util::safe_fopen(this->vid_path.c_str(), "wb");
-    assert(this->of);
+    if (!this->of) {
+      // write() already tolerates a null file; just log it
+      LOGE("failed to open %s: %s - not recording", this->vid_path.c_str(), strerror(errno));
+    }
+  }
+}
+
+// Turn the writer into a no-op after a storage failure: free any
+// partially-initialized ffmpeg state so the write/audio/dtor paths,
+// which are all gated on remuxing/of, never touch it again.
+void VideoWriter::disable() {
+  if (this->remuxing) {
+    if (this->audio_codec_ctx) avcodec_free_context(&this->audio_codec_ctx);
+    if (this->audio_frame) av_frame_free(&this->audio_frame);
+    if (this->ofmt_ctx) {
+      if (this->ofmt_ctx->pb) avio_closep(&this->ofmt_ctx->pb);
+      avformat_free_context(this->ofmt_ctx);
+      this->ofmt_ctx = nullptr;
+    }
+    if (this->codec_ctx) avcodec_free_context(&this->codec_ctx);
+    this->remuxing = false;
+  }
+  if (this->of) {
+    fclose(this->of);
+    this->of = nullptr;
   }
 }
 
@@ -104,10 +137,19 @@ void VideoWriter::write(uint8_t *data, int len, long long timestamp, bool codecc
         memcpy(codec_ctx->extradata, data, len);
       }
       int err = avcodec_parameters_from_context(out_stream->codecpar, codec_ctx);
-      assert(err >= 0);
+      if (err < 0) {
+        LOGE("avcodec_parameters_from_context failed %d - not recording %s", err, this->vid_path.c_str());
+        disable();
+        return;
+      }
       // if there is an audio stream, it must be initialized before this point
       err = avformat_write_header(ofmt_ctx, NULL);
-      assert(err >= 0);
+      if (err < 0) {
+        // storage failure (e.g. EIO/read-only remount) while writing the container header
+        LOGE("avformat_write_header failed %d - not recording %s", err, this->vid_path.c_str());
+        disable();
+        return;
+      }
       header_written = true;
     } else {
       // input timestamps are in microseconds
@@ -225,7 +267,7 @@ VideoWriter::~VideoWriter() {
     err = avio_closep(&this->ofmt_ctx->pb);
     if (err != 0) LOGE("avio_closep failed %d", err);
     avformat_free_context(this->ofmt_ctx);
-  } else {
+  } else if (this->of) {
     util::safe_fflush(this->of);
     fclose(this->of);
     this->of = nullptr;

--- a/system/loggerd/video_writer.h
+++ b/system/loggerd/video_writer.h
@@ -22,6 +22,7 @@ private:
   void initialize_audio(int sample_rate);
   void encode_and_write_audio_frame(AVFrame* frame);
   void process_remaining_audio();
+  void disable();
 
   std::string vid_path, lock_path;
   FILE *of = nullptr;

--- a/system/loggerd/zstd_writer.cc
+++ b/system/loggerd/zstd_writer.cc
@@ -2,11 +2,14 @@
 #include "system/loggerd/zstd_writer.h"
 
 #include <cassert>
+#include <cerrno>
+#include <cstring>
 
+#include "common/swaglog.h"
 #include "common/util.h"
 
 // Constructor: Initializes compression stream and opens file
-ZstdFileWriter::ZstdFileWriter(const std::string& filename, int compression_level) {
+ZstdFileWriter::ZstdFileWriter(const std::string& filename, int compression_level) : filename_(filename) {
   // Create the compression stream
   cstream_ = ZSTD_createCStream();
   assert(cstream_);
@@ -18,23 +21,35 @@ ZstdFileWriter::ZstdFileWriter(const std::string& filename, int compression_leve
   input_cache_.reserve(input_cache_capacity_);
   output_buffer_.resize(ZSTD_CStreamOutSize());
 
+  // a failed open leaves the writer in a no-op state instead of aborting,
+  // so loggerd survives log storage failure (e.g. an ext4 read-only remount)
   file_ = util::safe_fopen(filename.c_str(), "wb");
-  assert(file_ != nullptr);
+  if (file_ == nullptr) {
+    LOGE("ZstdFileWriter: failed to open %s: %s", filename.c_str(), strerror(errno));
+  }
 }
 
 // Destructor: Finalizes compression and closes file
 ZstdFileWriter::~ZstdFileWriter() {
-  flushCache(true);
-  util::safe_fflush(file_);
-
-  int err = fclose(file_);
-  assert(err == 0);
+  if (file_ != nullptr) {
+    if (!write_error_) {
+      flushCache(true);
+      util::safe_fflush(file_);
+    }
+    if (fclose(file_) != 0) {
+      LOGE("ZstdFileWriter: failed to close %s: %s", filename_.c_str(), strerror(errno));
+    }
+    file_ = nullptr;
+  }
 
   ZSTD_freeCStream(cstream_);
 }
 
 // Compresses and writes data to file
 void ZstdFileWriter::write(void* data, size_t size) {
+  // Drop data while the writer is broken so the cache can't grow unbounded
+  if (!ok()) return;
+
   // Add data to the input cache
   input_cache_.insert(input_cache_.end(), (uint8_t*)data, (uint8_t*)data + size);
 
@@ -46,6 +61,11 @@ void ZstdFileWriter::write(void* data, size_t size) {
 
 // Compress and flush the input cache to the file
 void ZstdFileWriter::flushCache(bool last_chunk) {
+  if (!ok()) {
+    input_cache_.clear();
+    return;
+  }
+
   ZSTD_inBuffer input = {input_cache_.data(), input_cache_.size(), 0};
   ZSTD_EndDirective mode = !last_chunk ? ZSTD_e_continue : ZSTD_e_end;
   int finished = 0;
@@ -56,7 +76,13 @@ void ZstdFileWriter::flushCache(bool last_chunk) {
     assert(!ZSTD_isError(remaining));
 
     size_t written = util::safe_fwrite(output_buffer_.data(), 1, output.pos, file_);
-    assert(written == output.pos);
+    if (written != output.pos) {
+      // storage failure (EIO/EROFS): latch the error and go no-op instead of aborting
+      LOGE("ZstdFileWriter: failed to write %s: %s", filename_.c_str(), strerror(errno));
+      write_error_ = true;
+      input_cache_.clear();
+      return;
+    }
 
     finished = last_chunk ? (remaining == 0) : (input.pos == input.size);
   } while (!finished);

--- a/system/loggerd/zstd_writer.h
+++ b/system/loggerd/zstd_writer.h
@@ -12,6 +12,7 @@ public:
   ~ZstdFileWriter();
   void write(void* data, size_t size);
   inline void write(kj::ArrayPtr<capnp::byte> array) { write(array.begin(), array.size()); }
+  inline bool ok() const { return file_ != nullptr && !write_error_; }
 
 private:
   void flushCache(bool last_chunk);
@@ -21,4 +22,6 @@ private:
   std::vector<char> output_buffer_;
   ZSTD_CStream *cstream_;
   FILE* file_ = nullptr;
+  bool write_error_ = false;
+  std::string filename_;
 };


### PR DESCRIPTION
# Fix engagement-blocking "Process Not Running: loggerd" when log storage fails mid-drive

## Symptom

On a comma three with a Samsung 980 NVMe, the first drive after a full power-off
regularly shows **"Process Not Running: loggerd"** for the entire drive. Because
`processNotRunning` is NO_ENTRY + SOFT_DISABLE, this **blocks engagement** and
**force-disengages** openpilot ~3s after it appears. A warm restart "fixes" it until
the next cold power-on.

## Root cause chain (fully instrumented on-device)

1. **~49 seconds after a cold power-on**, the Samsung 980 intermittently drops off
   the PCIe bus with a burst of I/O errors — same fingerprint every time:
   ```
   [   49.029089] blk_update_request: I/O error, dev nvme0n1, sector 9136
   [   49.029501] Buffer I/O error on dev nvme0n1, logical block 0, lost sync page write
   ```
   SMART shows zero media errors — a transport/controller failure, not dying flash.
   Warm reboots never trigger it (0/4); cold power-ons do, intermittently. Field
   instrumentation has since ruled OUT the drive's APST power-state feature as the
   mechanism (bursts occur with APST disabled); the exact trigger remains under
   investigation. Related: commaai/openpilot#34742, commaai/openpilot#35842.
2. ext4 on `/data/media` takes error hits and can **remount read-only** for the rest
   of the power session.
3. loggerd hits a caller-side `assert()` on its next disk op → **SIGABRT** (apport
   core captured) → the manager does not restart it → `processNotRunning` persists
   all drive.

## Fix — loggerd degrades gracefully instead of aborting

Protects against *any* storage failure, whatever the underlying hardware cause:

- `ZstdFileWriter` latches a `write_error_` flag on open/write failure and becomes a
  no-op — mirroring the existing graceful pattern in `VideoWriter::write`.
- `LoggerState::next()` returns false instead of asserting; the **segment counter
  still advances** so encoderd segment sync is preserved.
- `logger_rotate()` treats a failed rotation as one bounded retry per segment (~60s):
  **loggerd self-heals if storage recovers mid-route**.
- `VideoWriter` tolerates open/header failures via a `disable()` helper (also fixes a
  latent unconditional `fclose(NULL)` in its destructor).
- Encoder streams keep draining while degraded, so IPC queues never back up.
- bootlog exits cleanly if the log root is unavailable.

Net effect: storage failure costs that drive's logs — not openpilot engagement.

## Validation

- **Simulated (on the affected device)**: storage broken at startup → 100+s alive
  with bounded retries (stock SIGABRTs); healthy-path regression → 3 clean segments;
  mid-recording failure via ENOSPC → survives with one latched error per writer,
  **self-heals within one rotation** after space returns.
- **Field (boot-instrumented, ~48h)**: two real NVMe bursts captured in the wild
  (21 and 30 I/O-error lines at the ~49s signature, dozens of ext4 error lines).
  With this patch: **zero crashes, zero alerts, complete routes logged through both
  sessions** (3-segment and 42-segment routes, full-size rlogs). Before this patch,
  the identical event produced a SIGABRT core dump and an engagement-blocking alert
  for the rest of the drive.
- New degraded-mode case in `tests/test_logger.cc`.

## Follow-ups (separate PRs)

- #311 — manager: restart self-crashed processes (backport of commaai/openpilot#36755)
- #313 — swaglog: delete oldest (not newest) logs on rotation after restart
- #314 — logmessaged: drop records too big for the msgq queue instead of dying

🤖 Generated with [Claude Code](https://claude.com/claude-code)
