### PR TITLE
swaglog: delete oldest (not newest) logs on rotation after restart

### DIFF
--- a/common/swaglog.py
+++ b/common/swaglog.py
@@ -45,7 +45,8 @@ class SwaglogRotatingFileHandler(BaseRotatingHandler):
       fp = os.path.join(base_dir, fn)
       if fp.startswith(self.base_filename) and os.path.isfile(fp):
         log_files.append(fp)
-    return sorted(log_files)
+    # newest first, matching _open()'s insert(0, ...) so doRollover()'s pop() deletes the oldest
+    return sorted(log_files, reverse=True)
 
   def shouldRollover(self, record):
     size_exceeded = self.max_bytes > 0 and self.stream.tell() >= self.max_bytes

--- a/common/tests/test_swaglog.py
+++ b/common/tests/test_swaglog.py
@@ -1,0 +1,37 @@
+from openpilot.common.swaglog import SwaglogRotatingFileHandler
+
+
+def seed(base: str, indexes) -> None:
+  for i in indexes:
+    with open(f"{base}.{i:010}", "w") as f:
+      f.write("x")
+
+
+def existing(tmp_path) -> list[str]:
+  return sorted(f.name for f in tmp_path.iterdir())
+
+
+class TestSwaglogRotation:
+  def test_rollover_deletes_oldest_first(self, tmp_path):
+    base = str(tmp_path / "swaglog")
+    seed(base, range(8))  # swaglog.0000000000 .. swaglog.0000000007, exceeds backup_count
+
+    # restart over pre-existing files: __init__ rolls over, opening .8 and pruning to backup_count
+    handler = SwaglogRotatingFileHandler(base, backup_count=4)
+    try:
+      assert existing(tmp_path) == [f"swaglog.{i:010}" for i in (5, 6, 7, 8)]
+
+      # subsequent rollovers keep deleting oldest-first
+      handler.doRollover()
+      assert existing(tmp_path) == [f"swaglog.{i:010}" for i in (6, 7, 8, 9)]
+      handler.doRollover()
+      assert existing(tmp_path) == [f"swaglog.{i:010}" for i in (7, 8, 9, 10)]
+    finally:
+      handler.close()
+
+    # a second restart over the survivors keeps the same invariant
+    handler = SwaglogRotatingFileHandler(base, backup_count=4)
+    try:
+      assert existing(tmp_path) == [f"swaglog.{i:010}" for i in (8, 9, 10, 11)]
+    finally:
+      handler.close()


### PR DESCRIPTION
> Replaces #310, which was auto-closed by an accidental force-push to its head branch (a fork-tooling mishap — the fork is shared with upstream openpilot PR branches). Content unchanged.

## Description

`SwaglogRotatingFileHandler` maintains its file list newest-first — `_open()` prepends
each new file with `insert(0, ...)` and `doRollover()` prunes past `backup_count`
with `pop()` from the tail — but `get_existing_logfiles()` seeded the list
**oldest-first**. After any process restart at the 2500-file cap, the tail therefore
held the *newest* pre-existing file, and every rollover deleted the most recently
written logs, marching backwards through them, while months-old files survived.

Field evidence: on a real comma three, every boot destroyed the newest ~100+ swaglog
files from before the reboot — exactly the files needed to debug whatever caused the
reboot. This bug erased weeks of crash forensics during the #309 investigation
(logs from the failing boots kept vanishing days after being written).

**Fix**: one word — seed the list newest-first (`sorted(log_files, reverse=True)`)
to match the `insert(0)`/`pop()` convention.

## Verification

New `common/tests/test_swaglog.py`:
- fails on the unpatched base (restart prune deletes the wrong files), passes with the fix
- covers the restart prune, repeated rollovers, and a second restart over survivors
- verified on-device (comma three, red-on-bug → green-on-fix)

The same bug exists in upstream commaai/openpilot; submitted there separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
